### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -3,6 +3,9 @@
 
 name: Development Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/elan-language/LanguageAndIDE/security/code-scanning/1](https://github.com/elan-language/LanguageAndIDE/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow to apply minimal permissions (`contents: read`) to all jobs that do not explicitly define their own permissions. This ensures that the `build` job, which does not require write permissions, operates with the least privilege necessary. The `deploy` job already has its own specific permissions defined, so it will remain unaffected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
