### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@
 
 name: Release 
 
+permissions:
+  contents: read
+  actions: read
+  packages: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/elan-language/LanguageAndIDE/security/code-scanning/2](https://github.com/elan-language/LanguageAndIDE/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to explicitly define the minimal permissions required. Based on the workflow's steps, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `actions: read` for interacting with GitHub Actions artifacts.
- `packages: read` for caching Node.js dependencies.
- `id-token: write` if OpenID Connect tokens are required (not evident in this workflow).

We will add the `permissions` block at the top level of the workflow, ensuring it applies to all jobs. This will limit the `GITHUB_TOKEN` permissions to the least privilege required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
