### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/elan-language/LanguageAndIDE/security/code-scanning/4](https://github.com/elan-language/LanguageAndIDE/security/code-scanning/4)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the least privileges required. For this workflow, the minimal required permission is `contents: read`, as the workflow only needs to read the repository contents to run tests and upload artifacts. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
