### PR TITLE
Improve HTML validity for index page

### DIFF
--- a/src/web-content/index.html
+++ b/src/web-content/index.html
@@ -33,7 +33,7 @@
                         <div class="demo-file menu-item" id="demo/turtle-spiral.elan">Turtle Spiral</div>
                         <div class="demo-file menu-item" id="demo/turtle-snowflake.elan">Turtle Snowflake</div>
                         <div class="demo-file menu-item" id="demo/wordle-solver.elan">Wordle Solver</div>
-                        </div>          
+                        </div>
                 </div>
                 <div class="dropdown">
                     <button id="help" class="plain" tabindex="1">Help</button>
@@ -47,12 +47,12 @@
                         <div class="menu-item help-file"><a href="documentation/FAQs.html" target="_blank" rel="noopener noreferrer" tabindex="3">FAQs</a></div>  
                         <div class="menu-item help-file"><a href="documentation/AboutElan.html" target="_blank" rel="noopener noreferrer" tabindex="3">About Elan</a></div>
                         <div class="menu-item help-file"><a href="version-history.html" target="_blank" rel="noopener noreferrer" tabindex="3">Version history</a></div>
-                    </div>          
+                    </div>
                 </div>
                 <div class="dropdown">
                     <button id="file" class="plain" tabindex="1">File</button>
                     <div class="dropdown-content">
-                        <button class="plain menu-item" id="new" tabindex="1">New</buttonv>
+                        <button class="plain menu-item" id="new" tabindex="1">New</button>
                         <button class="plain menu-item" id="load"  tabindex="1">Load</button>
                         <button class="plain menu-item" id="append"  tabindex="1">Append</button>
                         <button class="plain menu-item" id="auto-save"  tabindex="1">Auto Save</button>
@@ -64,9 +64,9 @@
 
                 <button id="trim" class="plain" tabindex="1">Trim</button>
                 <button id="expand-collapse" class="plain" tabindex="1">+/-</button>
-                <button id="undo" class="plain" tabindex="1">Undo</button>  
+                <button id="undo" class="plain" tabindex="1">Undo</button>
                 <button id="redo" class="plain" tabindex="1">Redo</button>
-                
+
                 <dialog id="preferences-dialog">
                     <form>
 
@@ -80,7 +80,7 @@
                       </form>
                   </dialog>
                 <button id="logout" class="plain" tabindex="1" hidden="hidden">Logout</button>
-                <div id="code-title"></div>   
+                <div id="code-title"></div>
             </div>
             <div class="elan-code" data-code=""></div>
         </div>

--- a/src/web-content/index.html
+++ b/src/web-content/index.html
@@ -88,11 +88,11 @@
             <div id="rh-header">
                 <div id="rh-header-l">
                     <div id="run-controls">
-                        <button id="run-button" class="icon"  tabindex="1"><img src="images/Run.png"></button>
-                        <button id="run-debug-button" class="icon"  tabindex="1"><img src="images/Debug.png"></button>
-                        <button id="stop" class="icon" disabled  tabindex="1"><img src="images/Stop.png"></button>
-                        <button id="pause" class="icon" disabled title="Pause" tabindex="1"><img src="images/Pause.png"></button>
-                        <button id="step" class="icon" disabled title="Single Step" tabindex="1"><img src="images/Step.png"></button>
+                        <button id="run-button" class="icon" tabindex="1"><img src="images/Run.png" alt="Run the program"></button>
+                        <button id="run-debug-button" class="icon" tabindex="1"><img src="images/Debug.png" alt="Debug the program"></button>
+                        <button id="stop" class="icon" disabled tabindex="1"><img src="images/Stop.png" alt="Stop the program/tests"></button>
+                        <button id="pause" class="icon" disabled title="Pause" tabindex="1"><img src="images/Pause.png" alt="Pause the program"></button>
+                        <button id="step" class="icon" disabled title="Single Step" tabindex="1"><img src="images/Step.png" alt="Execute next instruction"></button>
                     </div>
                     <div id="display-title">
                         <button id="clear-display" class="plain" tabindex="2">Clear</button>


### PR DESCRIPTION
I've checked the markup on https://validator.w3.org, and it had some issues:

![image](https://github.com/user-attachments/assets/0145e41f-4454-4db9-abf9-e9acf10453bc)

I've used "Functional images" case to pick text alternatives, as was suggested by w3: https://www.w3.org/WAI/tutorials/images

After these changes, document has no errors, only "info" messages inherited from initial state

![image](https://github.com/user-attachments/assets/86553503-53d6-4ed1-8627-4501064af5a1)

P.S. Trailing whitespace was also removed
