### PR TITLE
Reserved words

### DIFF
--- a/src/documentation/ElanIndex.html
+++ b/src/documentation/ElanIndex.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div class="docTitle">Elan Index</div>
-<p> See also <a href="#PunctuationSymbols">Punctuation symbols</a> and <a href="#ReservedWords">Reserved words</a></p>
+<p> See also <a href="#PunctuationSymbols">Punctuation symbols</a></p>
 
 <p><a href="#A">A</a>&nbsp;&nbsp;<a href="#B">B</a>&nbsp;&nbsp;<a href="#C">C</a>&nbsp;&nbsp;<a href="#D">D</a>&nbsp;&nbsp;<a href="#E">E</a>&nbsp;&nbsp;<a href="#F">F</a>&nbsp;&nbsp;<a href="#G">G</a>&nbsp;&nbsp;<a href="#H">H</a>&nbsp;&nbsp;<a href="#I">I</a>&nbsp;&nbsp;<a href="#J">J</a>&nbsp;&nbsp;<a href="#K">K</a>&nbsp;&nbsp;<a href="#L">L</a>&nbsp;&nbsp;<a href="#M">M</a>&nbsp;&nbsp;<a href="#N">N</a>&nbsp;&nbsp;<a href="#O">O</a>&nbsp;&nbsp;<a href="#P">P</a>&nbsp;&nbsp;<a href="#Q">Q</a>&nbsp;&nbsp;<a href="#R">R</a>&nbsp;&nbsp;<a href="#S">S</a>&nbsp;&nbsp;<a href="#T">T</a>&nbsp;&nbsp;<a href="#U">U</a>&nbsp;&nbsp;<a href="#V">V</a>&nbsp;&nbsp;<a href="#W">W</a>&nbsp;&nbsp;<a href="#X">X</a>&nbsp;&nbsp;<a href="#Y">Y</a>&nbsp;&nbsp;<a href="#Z">Z</a></p>
 
@@ -396,12 +396,6 @@
 <tr><td><el-code><el-id>yellow</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr id="Z" class="subhead"><td colspan="3">Z &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 </table>
-
-<h2 id="ReservedWords">Reserved words</h2>
-<p>When choosing a name for an <a href="LangRef.html#Identifier">Identifier</a>, you cannot use any of the keyword or method names in the table above.
-Nor may you use any of the following reserved words:</p>
-<ul><li>action, arguments, array, async, await, boolean, break, by, byte, const, continue, curry, debugger, default, delete, dictionary, do, double, eval, export, extends, final, finally, float, goto, immutable, implements, import, in, instanceof, int, into, list, long, match, namespace, native, null, on, optional, otherwise, package, partial, pattern, protected, public, short, static, string, super, switch, system, synchronized, throws, todo, transient, typeof, void, volatile, when, yield.</li></ul>
-<p>They are all entirely in lower case, so you could capitalise any letters except the first to create a valid identifier, but that is not recommended.</p>
 
 <h2 id="PunctuationSymbols">Punctuation symbols</h2>
 <table>

--- a/src/documentation/LangRef.html
+++ b/src/documentation/LangRef.html
@@ -757,7 +757,7 @@ and the initial value is given by a following expression. For example:</p>
 <p>For all kinds of named values, the name must follow the rules for an &lsquo;identifier&rsquo;.
   It must start with a lower case letter, followed by any combination of lower case and upper case letters,
    numeric digits, and the _ (underscore) symbol. It may not contain spaces or other symbols.</p>
-<p>In addition, it cannot be any language keyword or method name, nor can it be a <a href="ElanIndex.html#ReservedWords">reserved word</a>.</p>
+<p>If you happen to choose a language keyword, method name or other reserved word, an error message will tell you that you cannot use it for an identifier.</p>
 
 <h2 id="scoping">Scoping and name qualification</h2>
 <p>With the exception of a <el-code>constant</el-code> (below), which is global in scope, named values are always &lsquo;local&rsquo;: their scope is confined to the method in which they are defined. </p>


### PR DESCRIPTION
List and guard against using reserved words as identifiers. 
Listed in ElanIndex, and cross-referred to LangRef Identifiers.