### PR TITLE
LibRef.html #1340 small changes

### DIFF
--- a/src/documentation/LibRef.html
+++ b/src/documentation/LibRef.html
@@ -250,12 +250,6 @@ in the range:</li>
   <td>(none)</td>
   <td><el-type>RegExp</el-type></td>
   <td>a new string that is a a converted to a regular expression:<br>no check is made of whether the result is a valid regular expression</td>
- </tr><tr id="asSet">
-  <td><el-method>asSet</el-method></td>
-  <td><el-type>String</el-type></td>
-  <td>(none)</td>
-  <td><el-type>Set</el-type></td>
-  <td> a <el-type>Set</el-type>of the <i>unique</i> characters in the string</td>
  </tr><tr id="contains_String">
   <td><el-method>contains</el-method></td>
   <td><el-type>String</el-type></td>
@@ -448,7 +442,7 @@ or from within another <el-kw>procedure</el-kw>, it is also possible to make cha
 with the specified changes &ndash; which is why all such methods have names starting <el-code>with...</el-code>.</p>
 
 <p>All four data structures contain values of a single Type, that Type being specified either explicitly &ndash;  as in
-    <el-code>of &lt;<el-kw>procedure</el-kw>&gt; <el-type>Int</el-type></el-code> &ndash; or implicitly if the structure
+    <el-code>&lt;<el-kw>of</el-kw> <el-type>Int</el-type>&gt;</el-code> &ndash; or implicitly if the structure
     is created from its literal definition form.</p>
     <p>A <el-type>Dictionary</el-type> is defined with two Types: one for its keys and one for their values.</p>
 
@@ -714,7 +708,7 @@ Note
   <td>(none)</td>
   <td><el-type>ListImmutable</el-type></td>
   <td>a new ListImmutable containing the same elements</td>
- </tr><tr id="asSet">
+ </tr><tr id="asSet_List">
   <td><el-method>asSet</el-method></td>
   <td><el-type>List</el-type></td>
   <td>(none)</td>
@@ -725,7 +719,7 @@ Note
   <td><el-type>List</el-type></td>
   <td>(none)</td>
   <td><el-type>String</el-type></td>
-  <td>a string representation of the List</td>
+  <td>a String that is a comma+space-separated list of the List's elements enclosed in square brackets</td>
  </tr><tr id="contains_List">
   <td><el-method>contains</el-method></td>
   <td><el-type>List</el-type></td>
@@ -799,29 +793,29 @@ Note
   <td><el-method>maxBy</el-method></td>
   <td><el-type>List</el-type></td>
   <td><el-kw>lambda</el-kw></td>
-  <td><el-type>List</el-type></td>
-  <td>a new List obtained from applying a lambda to the input List<br>
+  <td><el-type>List element's Type</el-type></td>
+  <td>list element corresponding to maximum of the values returned by a lambda<br>
   see <a href="#maxBy"><el-method>maxBy</el-method></a> in HoFs</td>
  </tr><tr id="minBy_List">
   <td><el-method>minBy</el-method></td>
   <td><el-type>List</el-type></td>
   <td><el-kw>lambda</el-kw></td>
-  <td><el-type>List</el-type></td>
-  <td>a new List obtained from applying a lambda to the input List<br>
+  <td><el-type>List element's Type</el-type></td>
+  <td>list element corresponding to minimum of the values returned by a lambda<br>
   see <a href="#minBy"><el-method>minBy</el-method></a> in HoFs</td>
  </tr><tr id="reduce_List">
   <td><el-method>reduce</el-method></td>
   <td><el-type>List</el-type></td>
   <td><el-kw>lambda</el-kw></td>
-  <td><el-type>List</el-type></td>
-  <td>a new List obtained from applying a lambda to the input List<br>
+  <td><el-type>return type of lambda</el-type></td>
+  <td>the final value obtained by applying a lambda cumulatively to each element in the input List<br>
   see <a href="#reduce"><el-method>reduce</el-method></a> in HoFs</td>
  </tr><tr id="sortBy_List">
   <td><el-method>sortBy</el-method></td>
   <td><el-type>List</el-type></td>
   <td><el-kw>lambda</el-kw></td>
   <td><el-type>List</el-type></td>
-  <td>a new List obtained from applying a lambda to the input List<br>
+  <td>a new list with the elements sorted according to the value returned by a lambda<br>
   see <a href="#sortBy"><el-method>sortBy</el-method></a> in HoFs</td>
  </tr><tr id="withAppend">
   <td><el-method>withAppend</el-method></td>
@@ -1039,8 +1033,13 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
  </tr><tr id="asList_ListImmutable">
   <td><el-method>asList</el-method></td>
   <td>(none)</td>
-  <td><el-type>ListImmutable</el-type></td>
+  <td><el-type>List</el-type></td>
   <td>copy of the <el-type>ListImmutable</el-type> as a <el-type>List</el-type></td>
+ </tr><tr id="asSet_ListImmutable">
+  <td><el-method>asSet</el-method></td>
+  <td>(none)</td>
+  <td><el-type>Set</el-type></td>
+  <td>a new Set containing all the <i>unique</i> elements in the List</td>
  </tr><tr id="asString_ListImmutable">
   <td><el-method>asString</el-method></td>
   <td>(none)</td>
@@ -1161,7 +1160,7 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
 
 <h2 id="SetType">Set</h2>
     <p>A set is a standard data structure that works somewhat like a <el-code>ListImmutable</el-code> with the important difference that in a set a given element may appear only once. If an item being added to a <el-code>Set</el-code> is identical to an existing item in the <el-code>Set</el-code> then the <el-code>Set</el-code> remains the same length as before. </p>
-    <p>This enables a set to work like a mathematical set so that it is possible to perform standard set operations such as <el-method>union</el-method> or <el-method>intersection</el-method>. For the same reason, a Set is an immutable data structure: there are no methods modify the set on which they are called, but several of them (including <el-method>add</el-method>, <el-method>remove</el-method>) return a new set that is based on the original set or sets, with specified differences.</p>
+    <p>This enables a set to work like a mathematical set so that it is possible to perform standard set operations such as <el-method>union</el-method> or <el-method>intersection</el-method>. For the same reason, a Set is an immutable data structure: there are no methods that modify the set on which they are called, but several of them (including <el-method>add</el-method>, <el-method>remove</el-method>) return a new set that is based on the original set or sets, with specified differences.</p>
     <p>Example of use:</p>
 <el-code-block source="set.elan">
 <el-statement class="ok" id="var3" tabindex="0"><el-kw>variable </el-kw><el-field id="var4" class="ok" tabindex="0"><el-txt><el-id>st</el-id></el-txt><el-place><i>name</i></el-place></el-field><el-kw> set to </el-kw><el-field id="expr5" class="ok" tabindex="0"><el-txt><el-kw>new</el-kw> <el-type>Set</el-type>&lt;<el-kw>of</el-kw> <el-type>Int</el-type>&gt;()</el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
@@ -1180,7 +1179,7 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
 <ul>
     <li> When creating a set, the Type of the elements must be specified in the form
     <el-code><el-type>Set</el-type>&lt;of <el-type>String</el-type>&gt;</el-code>. This applies both when creating a new, empty set and when defining the Type of a parameter to be a <el-code>Set</el-code>.</li>
-    <li>You can add elements: individually with <el-method>add</el-method>, or multiple elements with <el-code>addFromList</el-code> and <el-code>addFromList</el-code>.</li>
+    <li>You can add elements: individually with <el-method>add</el-method>, or multiple elements with <el-code>addFromList</el-code>.</li>
     <li>You can create a new set from an existing list or <el-code>ListImmutable</el-code> by calling <el-code>asSet</el-code> on it.</li>
 </ul>
 
@@ -1598,7 +1597,6 @@ most variables and data structures to the Display for debugging purposes.</p>
 <el-code-block source="TextFileReader_1.elan">
   <el-statement class="ok" id="let3" tabindex="0"><el-kw>let </el-kw><el-field id="var4" class="ok" tabindex="0"><el-txt><el-id>file</el-id></el-txt><el-place><i>name</i></el-place></el-field><el-kw> be </el-kw><el-field id="expr5" class="ok" tabindex="0"><el-txt><el-method>openFileForReading</el-method>()</el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
   <el-statement class="ok" id="let6" tabindex="0"><el-kw>let </el-kw><el-field id="var7" class="ok" tabindex="0"><el-txt><el-id>text</el-id></el-txt><el-place><i>name</i></el-place></el-field><el-kw> be </el-kw><el-field id="expr8" class="ok" tabindex="0"><el-txt><el-id>file</el-id>.<el-method>readWholeFile</el-method>()</el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
-  <el-statement class="ok" id="call9" tabindex="0"><el-top><el-kw>call </el-kw><el-field id="ident10" class="ok" tabindex="0"><el-txt><el-id>file</el-id>.<el-method>close</el-method></el-txt><el-place><i>procedureName</i></el-place></el-field>(<el-field id="args11" class="empty optional ok" tabindex="0"><el-txt></el-txt><el-place><i><i>arguments</i></i></el-place></el-field>)</el-top></el-statement>
   <el-statement class="ok" id="print12" tabindex="0"><el-kw>print </el-kw><el-field id="expr13" class="optional ok" tabindex="0"><el-txt><el-id>text</el-id></el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
 </el-code-block>
 <p>or to read a file line by line:</p>
@@ -1706,7 +1704,7 @@ most variables and data structures to the Display for debugging purposes.</p>
     (using <el-kw>print</el-kw> or any of the <el-method>print...</el-method> procedures)
     will be overlaid on top of this.</p>
 
-<p>You can programmatically clear just the Html display using the procedure <el-method>clearDisplay</el-method>.</p>
+<p>You can programmatically clear just the Html display using the procedure <el-method>clearHtml</el-method>.</p>
 
 <p>For specifying style or other attributes within Html tags, the attribute values should be enclosed in single quotation marks ' as shown above.
     Html will recognise single or double quotation marks, but entering double quotation marks would terminate the Elan string.
@@ -2129,7 +2127,7 @@ just as you would specify the Type of every parameter and the return Type for th
 
 <h2 id="parseAs">parseAsInt and parseAsFloat</h2>
     <p>Function <el-method>parseAsInt</el-method> attempts to parse the input <el-type>String</el-type> as an <el-type>Int</el-type>, and returns a 2-tuple, the first value of which is Boolean, with <el-code><el-id>true</el-id></el-code> indicating whether or not the parse has succeeded, and the second value being the resulting <el-type>Int</el-type>.
-        <el-method>parseAsFloat</el-method> does the equivalent for floating point. Operation is illustrated with by these tests: </p>
+        <el-method>parseAsFloat</el-method> does the equivalent for floating point. Operation is illustrated by these tests: </p>
 <el-code-block source="test_parse.elan">
 <el-test class="ok multiline" id="test88" tabindex="0">
 <el-top><el-expand>+</el-expand><el-kw>test </el-kw><el-field id="comment90" class="empty optional ok" tabindex="0"><el-txt></el-txt><el-place><i>optional description</i></el-place></el-field></el-top>
@@ -2323,7 +2321,7 @@ All the maths functions take a <el-type>Float</el-type> argument and return a <e
 <el-kw>end test</el-kw>
 </el-test>
 </el-code-block>
-<p>The result of <el-method>bitNot</el-method>(<el-id>a</el-id>)</el-code> being <el-code>-14</el-code> , when <el-code><el-id>a</el-id></el-code> is <el-code>13</el-code>, might be a surprise. But this is because the bitwise functions assume that the arguments are represented as 32-bit signed binary integers. So 13 is represented as <el-code>00000000000000000000000000001101</el-code>, and applying <el-method>bitAnd</el-method> gives <el-code>11111111111111111111111111110010 </el-code>which is the value <el-code>-14 </el-code>in signed two&#8217;s complement format, the left-most bit being the sign (<el-code>0</el-code> positive, <el-code>1</el-code> negative).</p>
+<p>The result of <el-method>bitNot</el-method>(<el-id>a</el-id>)</el-code> being <el-code>-14</el-code> , when <el-code><el-id>a</el-id></el-code> is <el-code>13</el-code>, might be a surprise. But this is because the bitwise functions assume that the arguments are represented as 32-bit signed binary integers. So 13 is represented as <el-code>00000000000000000000000000001101</el-code>, and applying <el-method>bitNot</el-method> gives <el-code>11111111111111111111111111110010 </el-code>which is the value <el-code>-14 </el-code>in signed two&#8217;s complement format, the left-most bit being the sign (<el-code>0</el-code> positive, <el-code>1</el-code> negative).</p>
 
 <h2 id="sequence">Sequence</h2>
 <p>The <el-method>sequence</el-method> is used to create a <el-type>List</el-type> containing a sequence


### PR DESCRIPTION
Changes to  in LibRef.html
- remove `String.asSet` -- doesn't exist
- improve descriptions in "Function methods on a List" table
- add `ListImmutable.asSet` to table
- minor wording corrections

(This is reapplying some of my changes from June 2nd that got lost)