### PR TITLE
Charles LangRef.html Literal Value etc IDEGuide.html links and HTML

### DIFF
--- a/src/documentation/IDEGuide.html
+++ b/src/documentation/IDEGuide.html
@@ -51,7 +51,7 @@ The <b>File</b> button has a drop-down menu with the following actions:
 
 <el-code-block>
 <div class="elan-code" data-code=""><el-header># <el-hash>c3a9b1928be74fe1bd94ec5d2cd07c9763a1031fbefe8de4d44d76669c1ad8f6</el-hash> <el-version>Elan 1.1.4</el-version> <el-user class="hide">guest</el-user> <el-profile class="hide">default_profile</el-profile></el-header>
-<el-global class="selected focused ok empty" id="select0" tabindex="0"><el-select><el-place>new code</el-place><el-help class="selector"> main procedure function test constant enum record class abstract interface #<el-help><a href="LangRef.html#GlobalInstructions" target="doc-iframe"> ?</a></el-help></el-select></el-global></div>
+<el-global class="selected focused ok empty" id="select0" tabindex="0"><el-select><el-place>new code</el-place><el-help class="selector"> main procedure function test constant enum record class abstract interface #</el-help><el-help><a href="LangRef.html#GlobalInstructions" target="doc-iframe"> ?</a></el-help></el-select></el-global></div>
 </el-code-block>
 
 <p>The first line shows a standard Elan 'header' comment, which is required on every code file, and which you are not able to move, edit, or delete.
@@ -208,7 +208,7 @@ The following example shows a <i>single instruction</i> that has been formatted 
     <el-statement class="selected focused ok" id="let15" tabindex="0"><el-kw>let </el-kw><el-field id="var16" class="ok" tabindex="0"><el-txt><el-id>b</el-id></el-txt><el-place><i>name</i></el-place></el-field><el-kw> be </el-kw><el-field id="expr17" class="ok" tabindex="0"><el-txt><el-kw>new</el-kw> <el-type>CircleVG</el-type>()<el-kw> with </el-kw><br><el-id>cx</el-id><el-kw> set to </el-kw><el-id>i</el-id>*<el-lit>5</el-lit> + <el-lit>2</el-lit>, <br><el-id>cy</el-id><el-kw> set to </el-kw><el-lit>75</el-lit>, <br><el-id>r</el-id><el-kw> set to </el-kw><el-lit>1</el-lit>, <br><el-id>fill</el-id><el-kw> set to </el-kw>-<el-lit>1</el-lit>, <br><el-id>stroke</el-id><el-kw> set to </el-kw><el-id>white</el-id></el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
 </el-code-block>
 
-<h3 class="no-TOC" id="field">Fields</h3>
+<h3 class="no-TOC" id="Field">Fields</h3>
 
 <p>Instructions consist of fixed (or 'templated') code &ndash; keywords and sometimes symbols &ndash; plus a number of 'fields' which is where you enter code that define specific details for that instruction.
     When the field is highlighted it will be highlighted with a background colour and a thin black border. This indicates that you may now enter or edit code in that field, for example:</p>
@@ -264,7 +264,7 @@ or, outside <el-code>main</el-code>:
 
     <p>When a new code selector has focus (for example as shown above)
         in most cases you can type just the first character of the instruction to be inserted. And you will then see
-        the template for that instruction including any mandatory and/or optional <a href="">fields</a>.
+        the template for that instruction including any mandatory and/or optional <a href="#Field">fields</a>.
         For example, given the initial list shown above, typing <el-code>f</el-code> will result in this being inserted:</p>
 
 <el-code-block>
@@ -309,12 +309,11 @@ In the following example, starting from this <a href="#MemberSelector">member se
 <h3 class="no-TOC" id="GlobalSelector">Global selector</h3>
 
 <p>The global selector appears only at 'global' level &ndash; in other words when the 'new code' is located <i>directly</i> within the file,
-rather than within <a href="#ContainerInstruction">container instruction</a>. When given focus, it will list the <a href="LangRef.html#global"></a>global instructions that
+rather than within <a href="#ContainerInstruction">container instruction</a>. When given focus, it will list the <a href="LangRef.html#GlobalInstructions">global instructions</a> that
 you may insert. This is the full list:</p>
 
 <el-code-block>
-<div>
-<el-global class="selected focused ok empty" id="select0" tabindex="0"><el-select><el-place>new code</el-place><el-help class="selector"> main procedure function test constant enum record class abstract interface #</div><el-help> <a href="documentation/LangRef.html#GlobalInstructions" target="doc-iframe">?</a></el-help></el-select></el-global></div>
+<el-global class="selected focused ok empty" id="select0" tabindex="0"><el-select><el-place>new code</el-place><el-help class="selector"> main procedure function test constant enum record class abstract interface #</el-help><el-help> <a href="documentation/LangRef.html#GlobalInstructions" target="doc-iframe">?</a></el-help></el-select></el-global>
 </el-code-block>
 
 Note that <el-code>main</el-code> will not be shown if the program already contains a <el-code>main</el-code> routine.
@@ -443,13 +442,13 @@ Note that <el-code>main</el-code> will not be shown if the program already conta
 <p>The <b>Worksheet</b> button opens buttons <b>Standard worksheets</b> and <b>Load external worksheet</b> to provide training materials.</p>
 
 <h1 id="Status">4. Status</h1>
-<h2>Status panel</h2>
+<h2 id="StatusPanel">Status panel</h2>
 <p>The status panel shows the current status of four conditions:</p>
 <ul>
- <li><b>Parse</b>: this indicator aggregates the parse status of each <a href="#field">field</a> and shows the <i>worst</i> status of any field.
+ <li><b>Parse</b>: this indicator aggregates the parse status of each <a href="#Field">field</a> and shows the <i>worst</i> status of any field.
     It is important to get the Parse Status to green <b>ok</b> at the earliest opportunity because, unless the parse status is green <b>ok</b>, Elan
         cannot attempt to <i>compile</i> the code. Nor can it <i>save</i> the code to a file, when the parse status is amber <b>incomplete</b> or red <b>error</b>.
-    </i></li>
+    </li>
  <li><b>Compile</b>: if the <i>parse</i> status is green <b>ok</b>, Elan will attempt to <i>compile</i> the code.</li>
  <li><b>Test</b>: 'pass' or 'fail' of the tests in the code</li>
  <li><b>Run</b>: 'running' to indicate the code is executing</li>

--- a/src/documentation/LangRef.html
+++ b/src/documentation/LangRef.html
@@ -258,12 +258,12 @@ The value is specified by the Type name for the specified <el-code>enum</el-code
   <li>Both are user-defined data structures</li>
   <li>Both are given a &lsquo;Type name&rsquo;</li>
   <li>Both may define one or more properties, each with a name and Type</li>
+  <li>Both may be created or copied using a <el-code>with</el-code> clause</li>
   <li>Both may define encapsulated methods</li>
 </ul>
 <p>However a <el-code>record</el-code> differs  from a <el-code>class</el-code> in that:</p>
  <ul>
   <li>A <el-code>record</el-code> is immutable (like a <el-code>ListImmutable</el-code> or a <el-code>String</el-code>). You can create a copy with specified differences but you cannot modify a <el-code>property</el-code> on a given instance.</li>
-  <li>A <el-code>record</el-code> instance may be created or copied using a <el-code>with</el-code> clause, whereas <el-code>with</el-code> may not be used on a class instance.</li>
   <li>A <el-code>record</el-code> does not define a constructor</li>
   <li>A <el-code>record</el-code> may define only <i>function</i> methods, since <i>procedure</i> methods would imply the ability to <i>mutate</i> the record.</li>
 </ul>
@@ -522,22 +522,22 @@ If the <el-kw>property</el-kw> is not initialised within the constructor then it
 <p>An abstract property may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) property to match.</p>
 
 <h2 id="AbstractProcedureMethod">Abstract Procedure Method</h2>
-<p>An abstract procedure method may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) property to match.</p>
+<p>An abstract procedure method may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) procedure to match.</p>
 
 <h2 id="abstractFunctionMethod">Abstract Function Method</h2>
-<p>An abstract function method may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) property to match.</p>
+<p>An abstract function method may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) function to match.</p>
 
 <h2 id="member_comment"># (comment)</h2>
 <p>See <a href="#Comment">Comments</a>.</p>
 
 <h1 id="StatementInstructions">Statement Instructions</h1>
 
-<a href="LibRef.html#assert">assert</a>
+<a href="#assert">assert</a>
 <a href="#call">call</a>
 <a href="#each">each</a>
-<a href="#else">else</a>
+<a href="#if_statement">else</a>
 <a href="#for">for</a>
-<a href="#if">if</a>
+<a href="#if_statement">if</a>
 <a href="#let">let</a>
 <a href="#print">print</a>
 <a href="#repeat">repeat</a>
@@ -584,7 +584,7 @@ by <a href="#throw">throwing an exception</a> like this:</p>
 <p>For procedures that you define yourself, <el-kw>out</el-kw> parameters are allowed.  In this case the corresponding argument must be the name of a variable whose value gets updated by the procedure.</p>
 <p>If the parameter is not an <el-kw>out</el-kw> parameter, any expression of the correct Type can be used as an argument.</p>
 <p>Procedures may have side-effects, for example input/output or changing a data value in an object. They can change the contents of any mutable object passed in as an argument.  For this reason, procedures cannot be called from functions, which are not allowed to have side-effects.  <el-kw>call</el-kw> statements are simply not allowed in functions, to enforce this.</p>
-<p>There is a limit to the complexity of a <el-kw>call</el-kw> statement.  Only one dot is allowed in the <el-code>procedure name</el-code> field, or two dots if the first word is <el-kw>property</el-kw>.  If you need anything more complicated, use a <el-kw>let</el-kw> statement on the line above.  See the error message explanation for <a href="#parse_proc_ref">Invalid reference to a procedure</a>.</p>
+<p>There is a limit to the complexity of a <el-kw>call</el-kw> statement.  Only one dot is allowed in the <el-code>procedure name</el-code> field, or two dots if the first word is <el-kw>property</el-kw>.  If you need anything more complicated, use a <el-kw>let</el-kw> statement on the line above.  See the error message explanation for <a href="#ProcRefField">'procedureName' in a call statement</a>.</p>
 
 <h2 id="each">Each loop</h2>
 <p>The <el-code>each..in..</el-code> construct specifies looping sequentially over the elements in a <el-type>List</el-type> or  an <el-type>Array</el-type>, or over the characters in a <el-type>String</el-type>.</p>
@@ -763,12 +763,25 @@ and the initial value is given by a following expression. For example:</p>
 
 <h2 id="LiteralValue">Literal value</h2>
 <p>A literal value is where a value is written &lsquo;literally&rsquo; in the code, such as <el-code>3.142</el-code> &ndash; in contrast to a value that is referred to by a name.</p>
-<p>The following data Types may be written as literal values (follow the links to view the form of each literal value):</p>
-<el-code><a href="#Int">Int</a>, <a href="#Float">Float</a>, <a href="#Boolean">Boolean</a>, <a href="#String">String</a>, <a href="#List">List</a>, <a href="#ListImmutable">ListImmutable</a>, <a href="#Dictionary">Dictionary</a>, <a href="#DictionaryImmutable">DictionaryImmutable</a>, <a href="#Tuple">Tuple</a></el-code><br>
+<p>Here is a table showing some example literal values.  Follow the links for more information about each type.</p>
+<table>
+<tr><th>Type</th><th>Example of literal</th></tr>
+<tr><td><a href="LibRef.html#Int">Int</a></td><td><el-code>3</el-code></td></tr>
+<tr><td><a href="LibRef.html#Float">Float</a></td><td><el-code>2.0</el-code></td></tr>
+<tr><td><a href="LibRef.html#Boolean">Boolean</a></td><td><el-code>true</el-code></td></tr>
+<tr><td><a href="LibRef.html#String">String</a></td><td><el-code>"Hello"</el-code></td></tr>
+<tr><td><a href="LibRef.html#Tuple">Tuple</a></td><td><el-code>tuple(3, "banana")</el-code></td></tr>
+<tr><td><a href="LibRef.html#List">List</a></td><td><el-code>["lemon", "lime", "orange"]</el-code></td></tr>
+<tr><td><a href="LibRef.html#Dictionary">Dictionary</a></td><td><el-code>["a":3, "b":5]</el-code></td></tr>
+<tr><td><a href="LibRef.html#ListImmutable">ListImmutable</a></td><td><el-code>{"lemon", "lime", "orange"}</el-code></td></tr>
+<tr><td><a href="LibRef.html#DictionaryImmutable">DictionaryImmutable</a></td><td><el-code>{"a":3, "b":5}</el-code></td></tr>
+</table>
+<p>For more about List and Dictionary literals see the <a href="LibRef.html#StandardDataStructures">Standard (mutable) data structures</a> table.<br>
+For more about ListImmutable and DictionaryImmutable literals see the <a href="LibRef.html#ImmutableDataStructures">Immutable data structures</a> table.</p>
 
 <h2 id="named_value">Named value</h2>
 <p>A named value is a value that is associated with a name rather than being defined literally in code. There are various kinds of named value:</p>
-<p><a href="#Constant">Constants</a>, <span class="Hyperlink"><a href="#Let_statement_1">let</a></span> statement, <span class="Hyperlink"><a href="#Variables">variable</a></span> statement, <a href="#Parameter_passing_1">Parameter passing</a>, <span class="Hyperlink"><a href="#Enum_1">enum</a></span> statement.
+<p><a href="#constant">Constants</a>, <span class="Hyperlink"><a href="#Let_statement_1">let</a></span> statement, <span class="Hyperlink"><a href="#Variables">variable</a></span> statement, <a href="#Parameter_passing_1">Parameter passing</a>, <span class="Hyperlink"><a href="#Enum_1">enum</a></span> statement.
   Once a named value has been defined, it can be referred to by the name.</p>
 
 <h2 id="Identifier">Identifier</h2>
@@ -791,7 +804,16 @@ If a variable is of an indexable Type, then an index or index range may be appli
     <el-code>print a[..7]</el-code>    &rarr; <el-code>Hello W</el-code>   (since the upper bound of a range is <em>exclusive</em>)
     <el-code>print a[0..4]</el-code>  &rarr; <el-code>Hell</el-code>         (for the same reason)
 </pre>
-<p>See also: <a href="#Using_a_List">Using a List</a>, <a href="#Using_a_Dictionary">Using a Dictionary</a></p>
+<p>In the examples above, the result is of type String in all cases.
+When using indexing on other types:</p>
+<ul>
+<li>with a single index, the result is the same type as the elements of the data structure being indexed</li>
+<li>with an index range, the result is the same type as the data structure itself</li>
+</ul>
+<p>Indexable types are <a href="LibRef.html#String">String</a>, <a href="LibRef.html#StandardDataStructures">Array, Array2D, List, Dictionary</a>, <a href="LibRef.html#ImmutableDataStructures">ListImmutable and DictionaryImmutable</a>.</p>
+<p>Index ranges cannot be applied to Dictionary or DictionaryImmutable.</p>
+<p>If the index values in a range are equal, or the second is smaller than the first,
+then an empty data structure of the correct type is generated.</p>
 <p>Important: unlike in many languages, indexes in Elan (whether, single, multiple, or a range) are only ever used for <em>reading</em> values.
 Writing a value to a specific index location is done through a method such as in these examples:</p>
 <pre>
@@ -857,9 +879,11 @@ example, which implements an &lsquo;exclusive or&rsquo;, need not use brackets a
 <ul>
 <li><el-code> a is b</el-code> returns <el-kw><el-id>true</el-id></el-kw>, if <el-code>a</el-code> and <el-code>b</el-code> are both of the same Type and their values are equal. The only exception is that if one argument is of Type <el-code>Float</el-code> and the other is of Type <el-code>Int</el-code>, then <el-code>is</el-code> will return <el-code>true</el-code> if their values are the same, i.e. are the same whole number.</li>
 <li><el-code>isnt</el-code> returns the opposite of <el-code>is</el-code>.</li>
-<p>Note that in Elan equality testing is always &lsquo;equality by value&rsquo;; there is no such thing as &lsquo;equality by reference&rsquo;.</p>
 <li>Where a binary operator is expected, as soon as you type <el-code>is</el-code> the editor will automatically insert a space after it. To enter <el-code>isnt</el-code> you need to delete the space (using the Backspace key) and then type <el-code>nt</el-code>.</li>
 </ul>
+<p>Note that in Elan equality testing is always &lsquo;equality by value&rsquo;; there is no such thing as &lsquo;equality by reference&rsquo;.</p>
+<p>If the items being compared are composite types, the elements within them are compared recursively to see if the objects are equal.  For example two distinct instances of the same class compare equal if the values of all their properties compare equal.  And two Lists compare equal if they contain the same elements in the same order.</p>
+<p>The compiler rejects any attempt to compare instances of different classes unless abstract classes and inheritance are involved.  Two instances which are subclasses of the same abstract class compare equal only if they are of the same class (and have the same property vlaues).</p>
 
 <h4 class="no-TOC">Numeric comparison</h4>
 <p>The numeric comparison operators are:</p>
@@ -1317,8 +1341,8 @@ Comments may be inserted at the same level as a <a href="#GlobalInstructions">gl
 
 <h3 id="TypeField" class="no-TOC">'Type' field in a function or property definition</h3>
  <p>For certain Types the name may be followed by an <el-kw>of</el-kw> clause, for example:</p>
-<el-type>List</el-type>&lt;<el-kw>of</el-kw> <el-Type>Int</el-Type>&gt;<br>
-<el-type>Dictionary</el-type>&lt;<el-kw>of</el-kw> <el-Type>String</el-Type>, <el-Type>Int</el-Type>&gt;
+<el-type>List</el-type>&lt;<el-kw>of</el-kw> <el-type>Int</el-type>&gt;<br>
+<el-type>Dictionary</el-type>&lt;<el-kw>of</el-kw> <el-type>String</el-type>, <el-type>Int</el-type>&gt;
 
 <h3 id="TypeNameField" class="no-TOC">'Name' field in a class or enum definition</h3>
  <p>Type names always begin with a capital letter,  optionally followed by letters of either case, numeric digits,


### PR DESCRIPTION
Two commits:

1. IDEGuide.html `#1327` HTML fixes and `#1340` corrections

- Fix a few mismatching HTML tags
- Add some id's for links and adjust some href's

2. LangRef.html `#1340` Literals, Indexed, "record with" etc

- "A record instance may be created or copied using a with clause, whereas with may not be used on a class instance."  Classes may now be copied with "with".
Move this sentence into the similarities list from the differences list and adjust.
- copy/paste error in Abstract Property / Abstract Procedure Method / Abstract Function Method
- Fix ids/href for assert, identifier, if and else.
- Bad link and heading near end of "Procedure call" section.
- The links in the "Literal Value" section don't take you to a place which describes literal values.
  Add a table of examples plus links to the tables in LibRef.
- Add more explanation to "Indexed Value" section, remove links that don't go anywhere ("See also: Using a List, Using a Dictionary")
- Add note about equality testing of instances of classes.
- el-Type -> el-type -- six off
