### PR TITLE
LangRef.html LibRef.html Concepts.html (new) #1340 Random, getKey, ke…

### DIFF
--- a/src/documentation/Concepts.html
+++ b/src/documentation/Concepts.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
+<link href="../styles/colourScheme.css" rel="stylesheet" />
+<link href="../styles/documentation.css" rel="stylesheet" />
+<link href="../styles/elanStyle.css" rel="stylesheet" />
+<title>Elan Concepts</title>
+<script type="text/javascript" src="generated_toc.js"></script>
+</head>
+<body>
+<div class="docTitle">Elan Concepts</div>
+<div id="docTOC">
+<div id="generated-toc" class="generate_from_h1 generate_for_page"></div></div>
+
+<h1 id="Introduction">Introduction</h1>
+<p>There are some concepts in the design of the Elan language and Integrated Development Environment which don't belong with any particular keyword or language construct described in the <a href="LangRef.html">Language Reference</a> or any particular data type or functionality in the <a href="LibRef.html">Library Reference</a>.</p>
+<p>This Concepts document is the place for those descriptions and explanations.</p>
+
+<h1 id="LanguageFeatures">Language Features</h1>
+<h2>Type Names</h2>
+<p>The Elan language has been carefully designed so that it supports static typing without the need for beginners to include the names of types in their programs.
+For example you can write a program that counts to 10 without using the type name "Int".</p>
+<p>But there comes a point when you need to refer to the names of types when defining:</p>
+<ul>
+<li>the parameters of a function or procedure</li>
+<li>the return value of a function</li>
+<li>the properties of a record or class</li>
+<li>a variable with an empty value, for example an empty List</li>
+<li>a data type whose elements have a particular type, for example an Array&lt;of Int&gt;</li>
+</ul>
+<p>The names of all the built-in types are specified in the <a href="LibRef.html">Library Reference</a>.
+You can create your own types as <a href="LangRef.html#class">class</a>es, <a href="LangRef.html#record">record</a>s and <a href="LangRef.html#enum">enum</a>s.</p>
+
+<h2 id="Methods">Method</h2>
+<p>We use the word "method" to describe functions and procedures in general.</p>
+
+<h2 id="DotMethods">Dot method</h2>
+<p>There are many functions and procedures which belong to system-defined types or user-defined classes, and operate on an instance of that type or class.</p>
+<p>For example the function <el-method>asString</el-method> can be invoked on an object instance <el-id>molePosition</el-id> like this:</p>
+<el-statement><el-code>if k is molePosition.asString() then</el-code></el-statement>
+<p>In this case, the variable <el-id>molePosition</el-id> is of type <el-type>Int</el-type>, and the Elan library provides the method <el-method>asString</el-method>.</p>
+<p>A procedure may be invoked like this:</p>
+<el-statement><el-code>call holes.put(molePosition, "*")</el-code></el-statement>
+<p>The variable <el-id>holes</el-id> is of type <el-type>Array&lt;of String&gt;</el-type>, and the Elan library provides the method <a href="LibRef.html#put_Array"><el-method>put</el-method></a> for changing one element of an Array.</p>
+<p>Functions and procedures that are defined as part of a user-defined <a href="LangRef.html#class">class</a>
+are also invoked from outside the class using a dot. For example a function:</p>
+<el-statement><el-code>set property.head to tail.getAdjacentSquare(property.currentDir)</el-code></el-statement>
+<p>and a procedure:</p>
+<el-statement><el-code>call apple.newRandomPosition(snake)</el-code></el-statement>
+<p>Collectively, these are known as dot methods.
+The functions and procedures that you define at a global level (ie not in a <a href="LangRef.html#class">class</a> or <a href="LangRef.html#record">record</a>) are not dot methods.
+There are also functions (eg <a href="LibRef.html#abs">abs</a>) and procedures (eg <a href="LibRef.html#clearPrintedText">clearPrintedText</a>)
+provided by the Elan Library which are standalone.
+That is, they are not dot methods, and are used without a dot.</p>
+
+<h2>Mutability</h2>
+<p>Some data structures are mutable and some are immutable.</p>
+<p>The properties or contents of an instance of an immutable type may not be changed,
+directly. However, you can easily create another instance that is a copy of the
+original, with all the same property values except for any specific changes
+that you want to make. The newly-minted copy (with changes) must be assigned
+to a new, or the same, named value.</p>
+<p>For examples of immutable types, see the five types described in the <a href="LibRef.html#ImmutableDataStructures">Immutable data structures</a> section of the Library Reference.
+<a href="LibRef.html#String">String</a>s are also immutable.</p>
+<p>The simple value types (Int, Float and Boolean) are also effectively immutable.  You can't change a single digit in a number in situ; you have to create a new number and assign it back to the original variable.</p>
+<p>User-defined <a href="LangRef.html#record">record</a>s are also immutable.</p>
+<p>User-defined <a href="LangRef.html#class">class</a>es are always treated as mutable.
+For example, you cannot put instances of classes into a ListImmutable or DictionaryImmutable,
+or use them as keys in a Dictionary.
+This applies even if the class has no procedure members, so is effectively immutable in practice (but then you may as well use a record).</p>
+<p><a href="LibRef.html#Tuple">tuple</a>s cannot be directly changed once they have been made, for eample you can't change just one element of a tuple.  But tuples are allowed to contain mutable types, eg a List&lt;of Int&gt;, so they are actually treated as mutable.</p>
+<p>The reason why mutability is of interest to computer scientists is that you can prove the correctness of programs more easily if they work with immutable data objects.  It also can reduce the number of bugs in your code, and can allow more optimisations when running a program.  It is widely used when writing code according to the functional programming paradigm.</p>
+
+<h2>Static typing</h2>
+<p>Elan is a statically typed language.
+Every variable and parameter has a defined type.</p>
+<p>For variables, the compiler can work out the type of the expression used to initialise the variable when it is declared.
+For example if you write this:</p>
+<el-statement><el-code>set n to 4</el-code></el-statement>
+<p>then the compiler defines the variable n to be of type <el-type>Int</el-type>, and only allows expressions of type <el-type>Int</el-type> to be assigned to it from there on.</p>
+<p>For parameters, and properties in classes and records, the programmer has to write in the type name, eg "<el-type>Int</el-type>":</p>
+<el-statement><el-code>function willLive(cell as Int, liveNeighbours as Int) returns Boolean</el-code></el-statement>
+<p>The return type of every function is also defined, which enables the compiler to decide the type of every expression.</p>
+
+<h2>Sound</h2>
+<p>To be written.</p>
+
+<h2>Case sensitivity</h2>
+<p>As far as we know, everything in Elan is case-sensitive.
+That is, no case folding is done, and the upper and lower case versions of a letter count as different characters.
+When you refer to a method or variable that you have defined, you must spell it exactly the same as the definition.</p>
+<p>If case folding is desired in a running program, you can do it explicitly by calling upperCase or lowerCase.</p>
+
+<h2>Parsing</h2>
+<p>[I wrote this before discovering the <a href="IDEGuide.html#StatusPanel">Status panel</a> section in the IDE Guide, which covers some of the same ground]</p>
+<p>Automatically, as you type your code, the Integrated Development Environment parses it.
+That is, it scans through the code trying to make sense of what it sees.
+Initially, the line of code is incomplete, and the Parse status in the top right hand corner shows "incomplete" on an orange background.
+As you type more, eventually the line will be complete enough that the parse status changes to "valid" on a green background.
+At this point you can type some more if you wish: for example "set n to n" is valid, but you may actually want to say "set n to n + 1".</p>
+<p>If you type something which could never be right, however much you add, the Parse status will go to "invalid" on a red background.  Any part of the line can be changed to make it right: every time you change any character, the parser starts again and re-evaluates the situation.</p>
+<p>For example, you may be trying to write "(n + 1)*2" but initially forget about the brackets and type "n + 1", then remember the brackets and type "n + 1)".  At this point it goes red, but don't be fazed: it is fine to go back to the start of the field, using the mouse or the left-arrow key, and change it to "(n + 1)", and at that point it will go green again.</p>
+
+<h2>Compilation</h2>
+<p>Once the Parse status is valid, the compilation stage starts.  The result is one of:</p>
+<ul>
+  <li>"ok" on a green background</li>
+  <li>"unknown" on an orange backgound</li>
+  <li>"error" on a red background</li>
+</ul>
+<p>In either of the error states, you can click on the coloured status and it will scroll the code window to (one of) the error(s). Clicking on the erroneous line should give further information as to what the problem is. If the message is unhelpful, please let us know how it can be improved.</p>
+<p>The unknown status usually appears if there is a name which it does not recognise.
+There is not much difference in practice between the "unknown" and "error" states.
+In neither case can the program be run.</p>
+<p>The idea is that the "error" state can usually be corrected by editing the line with the error,
+but the "unknown" state may need another variable, function etc defining before it is resolved.</p>
+
+<hr>
+<p><b>Elan Concepts</b> go to the <a href="#top">top</a></p>
+</body>
+</html>
+

--- a/src/documentation/LangRef.html
+++ b/src/documentation/LangRef.html
@@ -95,6 +95,8 @@ Unlike a function, a procedure does not return a value.
   <el-statement class="ok" id="print9" tabindex="0"><el-kw>print </el-kw><el-field id="expr10" class="optional ok" tabindex="0"><el-txt><el-id>li</el-id></el-txt><el-place><i>expression</i></el-place></el-field></el-statement>
 </el-code-block>
 
+<div id="return"></div>
+<div id="returns"></div>
 <h2 id="function">Function</h2>
 <p>A <el-code>function</el-code> is a named piece of code that can define <b>parameters</b> which are given inputs via <b>arguments</b> when reference to the function occurs in a statement or expression.</p>
 <p>Unlike a <a href="#procedure">procedure</a>, a function returns a value. Also unlike a procedure, a function can have no &lsquo;side effects&rsquo; and cannot depend on any <a href="LibRef.html#SystemMethods">System methods</a>.</p>
@@ -331,6 +333,7 @@ Having defined a record Type, such as <el-code>Game</el-code> above, you can cre
 <p>will read the <el-code>properties</el-code> into the four names defined.</p>
 When deconstructing, the names of the values must match the names of the <el-code>properties</el-code> of the <el-kw>record</el-kw>. However, the ordering of the names does not have to match the order in which the <el-code>properties</el-code> are defined in the <el-kw>record</el-kw>.
 
+<div id="this"></div>
 <h2 id="class">Class</h2>
 <!-- TODO Subclass and Superclass -->
 <div id="Subclass"></div>
@@ -535,9 +538,9 @@ If the <el-kw>property</el-kw> is not initialised within the constructor then it
 <a href="#assert">assert</a>
 <a href="#call">call</a>
 <a href="#each">each</a>
-<a href="#if_statement">else</a>
+<a href="#else">else</a>
 <a href="#for">for</a>
-<a href="#if_statement">if</a>
+<a href="#if">if</a>
 <a href="#let">let</a>
 <a href="#print">print</a>
 <a href="#repeat">repeat</a>
@@ -619,6 +622,8 @@ So if you have a variable <el-code>s</el-code> that holds a negative value to be
 </el-statement>
 </el-code-block>
 
+<div id="else"></div>
+<div id="if"></div>
 <h2 id="if_statement">If statement</h2>
 <p>See also <a href="#if_expression">if expression</a></p>
 <p>The <el-code>if..then..else..</el-code> and <el-code>if..then..else if..else..</el-code> constructs specify which of several code sequences is to be executed next.</p>
@@ -698,6 +703,8 @@ A <el-kw>set</el-kw> statement may not assign a new value to a parameter within 
 <p>You can deliberately generate, or &lsquo;throw&rsquo;, an exception when a specific circumstance is identified, using a <el-code>throw</el-code> statement, for example:</p>
 <el-code>throw exception "something has happened"</el-code><br>
 
+<div id="catch"></div>
+<div id="exception"></div>
 <h2 id="try">Try statement</h2>
 <p>You can test whether another piece of code might throw an exception by wrapping it in a <el-code>try</el-code> statement. This might arise when calling a <a href="LibRef.html#SystemMethods">System method</a> that is dependent upon external conditions, for example:</p>
 
@@ -784,12 +791,15 @@ For more about ListImmutable and DictionaryImmutable literals see the <a href="L
 <p><a href="#constant">Constants</a>, <span class="Hyperlink"><a href="#Let_statement_1">let</a></span> statement, <span class="Hyperlink"><a href="#Variables">variable</a></span> statement, <a href="#Parameter_passing_1">Parameter passing</a>, <span class="Hyperlink"><a href="#Enum_1">enum</a></span> statement.
   Once a named value has been defined, it can be referred to by the name.</p>
 
+<div id="identifier"></div><!-- Make both of these spellings work for the moment -->
 <h2 id="Identifier">Identifier</h2>
 <p>For all kinds of named values, the name must follow the rules for an &lsquo;identifier&rsquo;.
   It must start with a lower case letter, followed by any combination of lower case and upper case letters,
    numeric digits, and the _ (underscore) symbol. It may not contain spaces or other symbols.</p>
 <p>If you happen to choose a language keyword, method name or other reserved word, an error message will tell you that you cannot use it for an identifier.</p>
 
+<div id="global"></div>
+<div id="library"></div>
 <h2 id="scoping">Scoping and name qualification</h2>
 <p>With the exception of a <el-code>constant</el-code> (below), which is global in scope, named values are always &lsquo;local&rsquo;: their scope is confined to the method in which they are defined. </p>
 <p>Elan allows local named values to be defined with the same name as a constant, function, or procedure defined at global level or defined in the standard library. In such cases, when the name is used within the same method, then it will refer to the local definition. If you have done this, but then need to access the <el-code>constant</el-code>, <el-code>function</el-code>, or <el-code>procedure</el-code> with the same name, then you can simply prefix the use of the name with a &lsquo;qualifier&rsquo; of either <el-code>global.</el-code> or <el-code>library.</el-code> as appropriate.</p>
@@ -829,6 +839,7 @@ Writing a value to a specific index location is done through a method such as in
 <p>Arithmetic operators can be applied to <el-code>Float</el-code> or <el-code>Int</el-code> arguments. The result may be a <el-code>Float</el-code> or an <el-code>Int</el-code> depending on the arguments.</p>
 <p>For <el-code>^ + - *</el-code>, the result is a <el-code>Float</el-code> if either of the arguments is a <el-code>Float</el-code>, and an <el-code>Int</el-code> if both arguments are <el-code>Int</el-code>.</p>
 <p>For <el-code>/</el-code>, the result is always a <el-code>Float</el-code>.  It can be converted to an <el-code>Int</el-code> using the <a href="LibRef.html#floor">floor()</a> function.</p>
+<div id="div"></div>
 <p id="mod"><el-code>mod</el-code> and <el-code>div</el-code> only operate on <el-code>Int</el-code> arguments, and the result is <el-code>Int</el-code>.</p>
 <pre>
     <el-code>2^3</el-code>             &rarr;  <el-code>8</el-code>
@@ -991,6 +1002,8 @@ be followed by a 'with clause` in order to specify any property values. Example 
   </el-func>
 </el-code-block>
 
+<div id="copy"></div>
+<div id="with"></div>
 <h2 id="copy_with">Copy with</h2>
 <p>A 'copy with' expression is used to make a copy of an existing instance, but with a different value for one or more of the properties
   &ndash; either to assign to a named value, or as part of a more complex expression..

--- a/src/documentation/LibRef.html
+++ b/src/documentation/LibRef.html
@@ -619,6 +619,7 @@ Note
  <li>A List is created either empty or initialised from a literal definition.</li>
  <li>A List's size can be dynamically changed.</li>
 </ul>
+<div id="tail"></div>
 <h3 class="no-TOC" id="ListDeconstruction">List Deconstruction</h3>
 <p>A List or ListImmutable may be deconstructed into new variables or named values in a similar way to deconstructing a <a href="#Tuple">Tuple</a>, but in this case:</p>
 <ul>
@@ -1327,6 +1328,7 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
     <li>The methods for adding and removing an item are different for <el-type>Stack</el-type> and <el-type>Queue</el-type>, as shown here:</li>
 </ul>
 
+<div id="Stack_functions"></div><!-- so it works with both spellings -->
 <h3 class="no-TOC" id="StackFunctions">Function dot methods on a Stack</h3>
 <table class="tableMethod">
  <tr>
@@ -1369,6 +1371,7 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
  </tr>
 </table>
 
+<div id="Queue_functions"></div><!-- so it works with both spellings -->
 <h3 class="no-TOC" id="QueueFunctions">Function dot methods on a Queue</h3>
 <table class="tableMethod">
  <tr>
@@ -1648,6 +1651,33 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
 </ul>
 
 <h1 id="Input/output">Input/output</h1>
+
+<h2>Reading keys &#8216;on the fly&#8217;</h2>
+<p>In some applications &#8211; especially in games, for example &#8211; you want the program to react to a key pressed by the user, but without holding up the program to wait for value to be input. </p>
+<p>Whether your application makes use graphics, or just uses the <i>Console</i> for text, reading keystrokes &#8216;on the fly&#8217; is done via one of two methods:</p>
+<el-statement class="ok"><el-kw>let </el-kw><el-field class="ok"><el-txt><el-id>key1</el-id></el-txt></el-field><el-kw> be </el-kw><el-field class="ok"><el-txt><el-method>getKey</el-method>()</el-txt></el-field></el-statement>
+<el-statement class="ok"><el-kw>let </el-kw><el-field class="ok"><el-txt><el-id>key2</el-id>, <el-id>modifier</el-id></el-txt></el-field><el-kw> be </el-kw><el-field class="ok"><el-txt><el-method>getKeyWithModifier</el-method>()</el-txt></el-field></el-statement>
+<p><b>Notes</b></p>
+<ul>
+<li>When the <el-method>getKey</el-method> function is called, the system <i>does not wait for a response</i>. If a key has been pressed then that will be returned as a <b>String</b> e.g. <el-code>"a"</el-code>.</li>
+<li>Non-printable keys will be returned in the form: <b>"Backspace"</b>,"<b>Enter"</b>,<b>"ArrowDown"</b>,..</li>
+<li>If no key has been pressed (since the last time the method was called), it will return the empty string <el-code>""</el-code>. </li>
+<li>Pressing <i>just</i> the <b>Shift</b>, <b>Ctrl (Cmd under macOS)</b>, or <b>Alt</b> keys will not be detected by <el-method>getKey</el-method>. To read those keys use&#8230;</li>
+<li> <el-method>getKeyWithModifier</el-method> which returns a 2-tuple containing  the key pressed plus any &#8216;modifier&#8217; key such a <el-code>Shift</el-code>, <el-code>Ctrl</el-code>, or <el-code>Alt</el-code> (or the empty string if no modifier key is pressed).</li>
+<li>Both of these <el-method>getKey</el-method> methods are System methods because they have a dependency on the system and so may only be used within a <el-code>procedure</el-code> or in <el-code>main</el-code>.</li>
+</ul>
+<p>Use the procedure method <el-method>clearKeyBuffer()</el-method> if you want to enforce that the user cannot get too far ahead of the program by hitting keys in very rapid succession.</p>
+<p><el-method>waitForKey</el-method> waits for a key to be pressed, and returns it.  <el-method>pressAnyKeyToContinue</el-method> gives an optional prompt and is used when you don't need to know which key was pressed.</p>
+<el-code-block>
+<main class="ok multiline">
+<el-top><el-kw>main</el-kw></el-top>
+<el-statement class="ok"><el-top><el-kw>call </el-kw><el-field class="ok"><el-txt><el-method>pressAnyKeyToContinue</el-method></el-txt></el-field>(<el-field class="optional ok"><el-txt><el-id>true</el-id></el-txt></el-field>)</el-top></el-statement>
+<el-statement class="ok"><el-kw>print </el-kw><el-field class="optional ok"><el-txt>"<el-lit>OK, press A or B</el-lit>"</el-txt></el-field></el-statement>
+<el-statement class="ok"><el-kw>let </el-kw><el-field class="ok"><el-txt><el-id>mykey</el-id></el-txt></el-field><el-kw> be </el-kw><el-field class="ok"><el-txt><el-method>waitForKey</el-method>()</el-txt></el-field></el-statement>
+<el-statement class="ok"><el-kw>print </el-kw><el-field class="optional ok"><el-txt>"<el-lit>That was </el-lit>{<el-id>mykey</el-id>}<el-lit></el-lit>"</el-txt></el-field></el-statement>
+<el-kw>end main</el-kw>
+</main>
+</el-code-block>
 
 <h2 id="TextFileReader">Reading Text Files</h2>
 <p>The <el-type>TextFileReader</el-type> class is used to read textual data from a file.</p>
@@ -2049,8 +2079,8 @@ So for example the top left corner of the display is at (-100,75).</p>
  <li id="ImageVG"><el-code>ImageVG</el-code> for <el-code>&lt;image../&gt;</el-code></li>
 </ul>
 <p>The properties of the Elan shapes match the names of the attributes used in the SVG tags, except that the <el-code>stroke-width</el-code> attribute is changed to <el-code>strokeWidth</el-code> to make it a valid <a href="LangRef.html#identifier">Identifier</a>.</p>
-<p>Vector graphics are output to the Display pane in the user interface.
-<p>The area is 100 units wide by 75 units high, and both integer and floating point values of the units can be used.<p>
+<p>Vector graphics are output to the Display pane in the user interface.</p>
+<p>The area is 100 units wide by 75 units high, and both integer and floating point values of the units can be used.</p>
 <p>The origin for SVG units (0,0) is a the top left corner of the display: positive x rightwards, positive y downwards.
 So for exxample the centre of the display is at (50, 37.5).</p>
 <p>As with using SVG from Html, the shapes are drawn in the order in which they are added to the <el-type>VectorGraphic</el-type> instance:
@@ -2254,6 +2284,32 @@ So the constructors do not take any parameters, and instead you add a <el-kw>wit
 <h1>Other Types</h1>
 
 <h2 id="Random">Random</h2>
+<h4 class="no-TOC">Generating random numbers within a function</h4>
+<p>It is <i>not</i> possible to use the system methods <el-method>random()</el-method> or <el-method>randomInt()</el-method> within a function because they create unseen side-effects. You <i>may</i> use those system methods outside the function and pass the resulting random number (as an <el-type>Int</el-type> or a <el-type>Float</el-type>) as an argument <i>into </i>a function.</p>
+<p>It <i>is possible</i> to create and use random numbers <i>within a function</i>, but it requires a different approach and is a little more complex, using a special <i>Type</i> named <el-type>Random</el-type> (note that the <el-code>R</el-code> is in upper-case), as in this example:</p>
+<el-code-block source="func_random.elan">
+<main class="ok multiline">
+<el-top><el-kw>main</el-kw></el-top>
+<el-statement class="ok"><el-kw>variable </el-kw><el-field class="ok"><el-txt><el-id>rnd</el-id></el-txt></el-field><el-kw> set to </el-kw><el-field class="ok"><el-txt><el-kw>new</el-kw> <el-type>Random</el-type>()</el-txt></el-field></el-statement>
+<el-statement class="ok"><el-top><el-kw>call </el-kw><el-field class="ok"><el-txt><el-id>rnd</el-id>.<el-method>initialiseFromClock</el-method></el-txt></el-field>(<el-field class="empty optional ok"><el-txt></el-txt></el-field>)</el-top></el-statement>
+<el-statement class="ok"><el-kw>variable </el-kw><el-field class="ok"><el-txt><el-id>dice</el-id></el-txt></el-field><el-kw> set to </el-kw><el-field class="ok"><el-txt><el-lit>0</el-lit></el-txt></el-field></el-statement>
+<el-statement class="ok multiline">
+<el-top><el-kw>for </el-kw><el-field class="ok"><el-txt><el-id>i</el-id></el-txt></el-field><el-kw> from </el-kw><el-field class="ok"><el-txt><el-lit>1</el-lit></el-txt></el-field><el-kw> to </el-kw><el-field class="ok"><el-txt><el-lit>10</el-lit></el-txt></el-field><el-kw> step </el-kw><el-field class="ok"><el-txt><el-lit>1</el-lit></el-txt></el-field></el-top>
+<el-statement class="ok"><el-kw>set </el-kw><el-field class="ok"><el-txt><el-id>dice</el-id>, <el-id>rnd</el-id></el-txt></el-field><el-kw> to </el-kw><el-field class="ok"><el-txt><el-method>rollDice</el-method>(<el-id>rnd</el-id>)</el-txt></el-field></el-statement>
+<el-statement class="ok"><el-kw>print </el-kw><el-field class="optional ok"><el-txt><el-id>dice</el-id></el-txt></el-field></el-statement>
+<el-kw>end for</el-kw>
+</el-statement>
+<el-kw>end main</el-kw>
+</main>
+<el-func class="ok multiline">
+<el-top><el-kw>function </el-kw><el-method><el-field class="ok"><el-txt>rollDice</el-txt></el-field></el-method>(<el-field class="optional ok"><el-txt><el-id>rnd</el-id> <el-kw>as</el-kw> <el-type>Random</el-type></el-txt></el-field>)<el-kw> returns </el-kw><el-field class="ok"><el-txt>(<el-type>Int</el-type>, <el-type>Random</el-type>)</el-txt></el-field></el-top>
+<el-statement class="ok"><el-kw>return </el-kw><el-field class="ok"><el-txt><el-id>rnd</el-id>.<el-method>nextInt</el-method>(<el-lit>1</el-lit>, <el-lit>6</el-lit>)</el-txt></el-field></el-statement>
+<el-kw>end function</el-kw>
+</el-func>
+</el-code-block>
+<p>The <el-type>Random</el-type> Type defines two &#8216;function methods&#8217;: <el-method>next</el-method> and <el-method>nextInt</el-method>.</p>
+<p>Both of them return a 2-Tuple consisting of the random value (as either a <el-code>Float</el-code> or an <el-code>Int</el-code> respectively) plus a new <el-type>Random</el-type>. The <i>new</i> (returned) <el-type>Random</el-type> must be used for generating the subsequent random number (if more are required). If you call <el-code>next</el-code> repeatedly on the same instance of Random, you will always get the same value. </p>
+<p>As shown in the example, when<i> first created </i>you should call <el-method>initialiseWithClock()</el-method> on it. If you remove that call statement from the code above, the program will still generate a sequence of randomised values, <i>but the sequence will be exactly the same each time you run the program.</i> Initialising from the clock ensures that you get a different sequence each run. Using Random <i>without</i> so initialising, however, can be extremely useful for testing purposes since the results are repeatable.</p>
 
 <h2 id="Func">Func</h2>
 <p>A function may be passed as an argument into another function (or a procedure), or returned as the result of calling another function.
@@ -2679,11 +2735,6 @@ of integer values as defined by the two (integer) parameters: <el-code><el-id>st
   <td>(none)</td>
   <td><el-type>String</el-type></td>
   <td>returns the last character pressed on the keyboard during program execution</td>
- </tr><tr id="getKey">
-  <td><el-method>getKey</el-method></td>
-  <td>(none)</td>
-  <td><el-type>String</el-type></td>
-  <td>returns the character of the keyboard key pressed</td>
  </tr><tr id="getKeyWithModifier">
   <td><el-method>getKeyWithModifier</el-method></td>
   <td>(none)</td>
@@ -2737,11 +2788,6 @@ of integer values as defined by the two (integer) parameters: <el-code><el-id>st
   <td>(none)</td>
   <td><el-class>TextFileReader</el-class></td>
   <td>see <a href="#Input/output">Input/output</a></td>
- </tr><tr id="pressAnyKeyToContinue">
-  <td><el-method>pressAnyKeyToContinue</el-method></td>
-  <td>(none)</td>
-  <td>(none)</td>
-  <td>pauses execution of the program until a keyboard key is pressed</td>
  </tr><tr id="random">
   <td><el-method>random</el-method></td>
   <td>(none)</td>
@@ -2780,6 +2826,16 @@ of integer values as defined by the two (integer) parameters: <el-code><el-id>st
 <p>The Elan standard library contains several HoFs that are widely recognised and used within functional programming.</p>
 
 <h2 id="ref">Passing a function as a reference</h2>
+<p>To use a higher-order function (HoF), you have to pass in a reference to a function.
+This can be either a <a href="#lambda"><el-kw>lambda</el-kw></a> or the keyword <el-kw>ref</el-kw> followed by the name of a function.</p>
+<p>It is also possible to use references to functions not in the context of HoFs.</p>
+<p>On most occasions when you write the name of an existing function elsewhere in code your intent is to <i>evaluate</i> the function and, to do so, you write the name of the function followed by brackets containing such arguments as are required by the function. For this reason if you forget to add the brackets, you will get an error, for example:</p>
+<p><el-code>To evaluate function 'myfunction' add brackets. Or to create a reference to 'myfunction', precede it by 'ref'.</el-code></p>
+<p>The second sentence in this error message is for when your intention is <i>not</i> to evaluate the function, but to create a <i>reference </i>to the function. This is a valid thing to do in functional programming but is not generally done in procedural programming. As the error message says, to create a reference to a function you need to precede it by <el-code>ref</el-code> and the name of the function should then <i>not</i> be followed by brackets (or any arguments). For example:</p>
+<el-statement><el-code>variable passes set to allPupils.filter(ref passedMathsTest)</el-code></el-statement>
+<el-statement><el-code>function passedMathsTest(p as Pupil) as Boolean</el-code></el-statement>
+<el-statement><el-code>&#160; return p.mathsPercent &gt; 35</el-code></el-statement>
+<el-statement><el-code>end function</el-code></el-statement>
 
 <h2>Defining your own HoFs</h2>
 


### PR DESCRIPTION
…yword ids etc

Quite a lot changed but I decided to make it all one commit, as easier to manage, assuming that it doesn't all need unravelling. But it is in three parts.
Rather long, but I like to have a record of what I changed.

1. LangRef.html #1340 add some more keywords as id's

I erroneously changed an "if" and an "else" link from href="#if" to href="#if_statement" to make it work in a previous commit.  Now I realise that a better route is to add id="if" and id="else" in extra little div's as we need them for links from the IDE. So I have edited those two lines back how they were (#else and #if) before that change (Commit ae65b05) (not sure if GitHub intelligently links commit IDs: https://github.com/elan-language/LanguageAndIDE/commit/ae65b052ac5c03dca91c549f8e5312cd174e107a). I have added quite a lot of extra `<div id="whatever"></div>` id's for keywords for the IDE to use as targets. I'm not sure that it will use all of them, but no harm if a few extra. A few still to consider, some of which need some text writing: image, out, ref, this (I have put id "this"  on the "class" section, but there is no description of "this").  I don't know how we handle links to LibRef eg for "image". PS I have put a section about "ref" in LibRef, but I expect the IDE will refer to LangRef.html#ref if anywhere so that will need sorting out.

Also I broke id "identifier" in one place.  Add `<div id="identifier">` so that "identifier" and "Identifer" both work.  We can always tidy it up in slow time.

2. LibRef.html #1340 Type Random, getKey etc, function ref, ids

- Add section on the type Random, ported from the old Elan 6 manual
- Add section "Reading keys ‘on the fly’", ported from the old Elan 6 manual
- Remove duplicate table entries for getKey and pressAnyKeyToContinue
- Add extra ids for Stack_functions and Queue_functions so it works and maintains the convention in the row where the hrefs appear. It can be tidied once we decide on a convention.
- Add extra id for `<div id="tail"></div>` on `<h3 class="no-TOC" id="ListDeconstruction">List Deconstruction</h3>`.  There is a reference in ElanIndex.html.
- Fill in the section "Passing a function as a reference", copied from the old Elan 6 manual. This is actually a language feature not a library feature, but there was a heading already there in LibRef.html, where higher-order functions are discussed.  Good enough for the moment.

3. New file documentation/Concepts.html #1340

Bernard suggested that we need another document which covers topics which don't really live in LangRef.html or LibRef.html, so I have created Concepts.html. Partly on the principle that it sometimes helps to write *something* to clarify the options. Three of the sections I wrote (or ported across from the Elan 6 manual) ended up being more suitable for LangRef or LibRef so I dropped them in there. That makes the Concepts document rather thin.
Also I wasn't sure what was wanted, so I didn't write too much in case I was on the wrong track. I am happy to have it published -- I don't think there is anything libellous in there. And other people may suggest topics.