### PR TITLE
ElanIndex LangRef LibRef #1340 id href fixes

### DIFF
--- a/src/documentation/Concepts.html
+++ b/src/documentation/Concepts.html
@@ -54,7 +54,8 @@ There are also functions (eg <a href="LibRef.html#abs">abs</a>) and procedures (
 provided by the Elan Library which are standalone.
 That is, they are not dot methods, and are used without a dot.</p>
 
-<h2>Mutability</h2>
+<div id="Mutable"></div>
+<h2 id="Mutability">Mutability</h2>
 <p>Some data structures are mutable and some are immutable.</p>
 <p>The properties or contents of an instance of an immutable type may not be changed,
 directly. However, you can easily create another instance that is a copy of the

--- a/src/documentation/ElanIndex.html
+++ b/src/documentation/ElanIndex.html
@@ -119,8 +119,8 @@
 <tr><td><el-code><el-method>displayBlocks</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
 <tr><td><el-code><el-method>displayHtml</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#displayHtml">Displaying Html</a></td></tr>
 <tr><td><el-code><el-method>displayVectorGraphics</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-kw>div</el-kw></el-code></td><td>keyword</td><td>see <a href="LibRef.html#div">div</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr class="x"><td>Dot method</td><td>topic</td><td>see <a href="LangRef.html#DotMethods">Dot methods</a></td></tr>
+<tr><td><el-code><el-kw>div</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#div">div</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
+<tr class="x"><td>Dot method</td><td>topic</td><td>see <a href="Concepts.html#DotMethods">Dot methods</a></td></tr>
 <tr id="E" class="subhead"><td colspan="3">E &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td><el-code><el-kw>each</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#each">Each loop</a></td></tr>
 <tr><td>Editor</td><td>IDE</td><td>see <a href="IDEGuide.html#Editor">Code editor</a></td></tr>
@@ -182,14 +182,14 @@
 <tr><td>Indexed value</td><td>topic</td><td>see <a href="LangRef.html#IndexedValue">Indexed Value</a></td></tr>
 <tr><td><el-code><el-method>indexOf</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
 <tr><td>Inheritance</td><td>topic</td><td>see <a href="LangRef.html#Inheritance">Inheritance</a></td></tr>
-<tr><td><el-code><el-kw>inherits</el-kw></el-code></td><td>keyword</td><td>see <a href="LibRef.html#Inheritance">Inheritance</a></td></tr>
+<tr><td><el-code><el-kw>inherits</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#Inheritance">Inheritance</a></td></tr>
 <tr><td>Input, keyboard</td><td>topic</td><td>see <a href="IDEGuide.html#Keyboard">Keyboard</a></td></tr>
 <tr><td>Input, file</td><td>topic</td><td>see <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr><td><el-code><el-method>inputFloat</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputFloat">inputFloat</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>inputFloatBetween</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputFloatBetween">inputFloatBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>inputInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputInt">inputInt</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>inputIntBetween</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputIntBetween">inputIntBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputString</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputString">inputString</a> in <a href="LibRef.html#System methods">System methods</a></td></tr>
+<tr><td><el-code><el-method>inputString</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputString">inputString</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>inputStringFromOptions</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputStringFromOptions">inputStringFromOptions</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>inputStringWithLimits</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputStringWithLimits">inputStringWithLimits</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td><el-code><el-method>insert</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#insert">insert</a> in <a href="LibRef.html#List">List</a></td></tr>
@@ -239,17 +239,16 @@
 <tr><td><el-code><el-method>minInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minInt">minInt</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td>Member instructions</td><td>topic</td><td>see <a href="LangRef.html#MemberInstructions">Member instructions</a></td></tr>
 <tr><td>Member selector</td><td>IDE</td><td>see <a href="IDEGuide.html#MemberSelector">Member selector</a></td></tr>
-<tr class="x"><td>Method</td><td>topic</td><td>see <a href="LibRef.html#Methods">Methods</a></td></tr>
-<tr><td><el-code><el-method>min</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#max/min">min</a></td></tr>
-<tr><td><el-code><el-method>minBy</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minBy">minBy</a> in <a href="LibRef.html#HoF">Higher-order Functions</a></td></tr>
+<tr class="x"><td>Method</td><td>topic</td><td>see <a href="LangRef.html#Methods">Methods</a></td></tr>
+<tr><td><el-code><el-method>minBy</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minBy">minBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
 <tr><td><el-code><el-kw>mod</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#mod">mod</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
 <tr><td>Mouse</td><td>topic</td><td>see <a href="IDEGuide.html#Mouse">Mouse</a></td></tr>
 <tr><td><el-code><el-method>move</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#move">Turtle graphics</a></td></tr>
 <tr><td><el-code><el-method>moveTo</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#moveTo">Turtle graphics</a></td></tr>
-<tr class="x"><td>Mutability</td><td>topic</td><td>see <a href="LangRef.html#Mutable">Mutability and immutability</a></td></tr>
+<tr class="x"><td>Mutability</td><td>topic</td><td>see <a href="Concepts.html#Mutable">Mutability and immutability</a></td></tr>
 <tr id="N" class="subhead"><td colspan="3">N &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Named value</td><td>topic</td><td>see <a href="LangRef.html#named_value">Named value</a></td></tr>
-<tr><td><el-code><el-kw>new</el-kw></el-code></td><td>keyword</td><td>see <a href="LibRef.html#new">New instance</a></td></tr>
+<tr><td><el-code><el-kw>new</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#new">New instance</a></td></tr>
 <tr><td><el-code><el-kw>not</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
 <tr><td>Numeric comparison</td><td>topic</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
 <tr id="O" class="subhead"><td colspan="3">O &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
@@ -350,7 +349,7 @@
 <tr><td><el-code><el-kw>test</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#test">Tests</a></td></tr>
 <tr><td><el-code><el-type>TextFileReader</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TextFileReader">TextFileReader</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr><td><el-code><el-type>TextFileWriter</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TextFileWriter">TextFileWriter</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-type>TextVG</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TextVG">TextVG</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-code><el-type>TextVG</el-type></el-code></td><td>Type</td><td>TextVG has not been implemented yet, and will be in a future release</td></tr>
 <tr><td><el-code><el-kw>then</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
 <tr><td><el-code><el-kw>throw</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#throw">Throw statement</a></td></tr>
 <tr><td><el-code><el-kw>to</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
@@ -371,7 +370,7 @@
 <tr><td>Value Type</td><td>topic</td><td>see <a href="LibRef.html#ValueTypes">Value Types</a></td></tr>
 <tr><td><el-code><el-method>values</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#values">values</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
 <tr><td><el-code><el-kw>variable</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#variable">Variable statement</a></td></tr>
-<tr><td><el-code><el-type>VectorGraphic</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#vectorGraphic">vectorGraphic</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-code><el-type>VectorGraphic</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#VectorGraphic">VectorGraphic</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr><td>Vector graphics</td><td>topic</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr id="W" class="subhead"><td colspan="3">W &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td><el-code><el-method>waitForKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#waitForKey">waitForKey</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
@@ -380,10 +379,8 @@
 <tr><td><el-code><el-kw>with</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#copyWith">Copy with</a></td></tr>
 <tr><td><el-code><el-method>withInsert</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withInsert">withInsert</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td><el-code><el-method>withPut</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>withPutKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withPutKey">withPutKey</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
 <tr><td><el-code><el-method>withRemoveAll</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveAll">withRemoveAll</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>withRemoveAt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveAt">withRemoveAt</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>withRemoveAtKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveAtKey">withRemoveAtKey</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
+<tr><td><el-code><el-method>withRemoveAt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
 <tr><td><el-code><el-method>withRemoveFirst</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveFirst">withRemoveFirst</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td><el-code><el-method>writeLine</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#writeLine">writeLine</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr><td><el-code><el-method>writeWholeFile</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#writeWholeFile">writeWholeFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>

--- a/src/documentation/LangRef.html
+++ b/src/documentation/LangRef.html
@@ -14,6 +14,7 @@
 <div id="docTOC">
 <div id="generated-toc" class="generate_from_h1 generate_for_page"></div></div>
 
+<div id="Methods"></div>
 <h1 id="GlobalInstructions">Global Instructions</h1>
 <p>
  <a href="#main">main</a>,
@@ -224,7 +225,7 @@ Procedures and functions may be called or referenced recursively. For example, a
 <el-const class="ok multiline" id="const75" tabindex="0"><el-top><el-expand>+</el-expand><el-kw>constant </el-kw><el-field id="ident76" class="ok" tabindex="0"><el-txt><el-id>colours</el-id></el-txt><el-place><i>name</i></el-place></el-field></el-top><el-kw> set to </el-kw><el-field id="text77" class="ok" tabindex="0"><el-txt>{<el-type>Suit</el-type>.<el-id>spades</el-id>:<el-id>black</el-id>, <el-type>Suit</el-type>.<el-id>hearts</el-id>:<el-id>red</el-id>, <el-type>Suit</el-type>.<el-id>diamonds</el-id>:<el-id>red</el-id>, <el-type>Suit</el-type>.<el-id>clubs</el-id>:<el-id>black</el-id>}</el-txt><el-place><i>literal value or data structure</i></el-place></el-field></el-const>
 <el-const class="ok multiline" id="const65" tabindex="0"><el-top><el-expand>+</el-expand><el-kw>constant </el-kw><el-field id="ident66" class="ok" tabindex="0"><el-txt><el-id>scrabbleValues</el-id></el-txt><el-place><i>name</i></el-place></el-field></el-top><el-kw> set to </el-kw><el-field id="text67" class="ok" tabindex="0"><el-txt>{"<el-lit>A</el-lit>":<el-lit>1</el-lit>, "<el-lit>B</el-lit>":<el-lit>3</el-lit>, "<el-lit>C</el-lit>":<el-lit>3</el-lit>, "<el-lit>D</el-lit>":<el-lit>2</el-lit>, "<el-lit>E</el-lit>":<el-lit>1</el-lit>, "<el-lit>F</el-lit>":<el-lit>4</el-lit>, "<el-lit>G</el-lit>":<el-lit>2</el-lit>, "<el-lit>H</el-lit>":<el-lit>4</el-lit>, "<el-lit>I</el-lit>":<el-lit>1</el-lit>, "<el-lit>J</el-lit>":<el-lit>8</el-lit>, "<el-lit>K</el-lit>":<el-lit>5</el-lit>, "<el-lit>L</el-lit>":<el-lit>1</el-lit>, "<el-lit>M</el-lit>":<el-lit>3</el-lit>, "<el-lit>N</el-lit>":<el-lit>1</el-lit>, "<el-lit>O</el-lit>":<el-lit>1</el-lit>, "<el-lit>P</el-lit>":<el-lit>3</el-lit>, "<el-lit>Q</el-lit>":<el-lit>10</el-lit>, "<el-lit>R</el-lit>":<el-lit>1</el-lit>, "<el-lit>S</el-lit>":<el-lit>1</el-lit>, "<el-lit>T</el-lit>":<el-lit>1</el-lit>, "<el-lit>U</el-lit>":<el-lit>1</el-lit>, "<el-lit>V</el-lit>":<el-lit>4</el-lit>, "<el-lit>W</el-lit>":<el-lit>4</el-lit>, "<el-lit>X</el-lit>":<el-lit>8</el-lit>, "<el-lit>Y</el-lit>":<el-lit>4</el-lit>, "<el-lit>Z</el-lit>":<el-lit>10</el-lit>}</el-txt><el-place><i>literal value or data structure</i></el-place></el-field></el-const>
 </el-code-block>
-<p>In the <el-id>colours</el-id> example, <el-code>Suit</el-code> is an <a href="#Enum_1">Enum</a>.</p>
+<p>In the <el-id>colours</el-id> example, <el-code>Suit</el-code> is an <a href="#enum">Enum</a>.</p>
 
 <h2 id="enum">Enum</h2>
 <p>An <el-code>enum</el-code> &ndash; short for &lsquo;enumeration&rsquo; &ndash; is the simplest form of &lsquo;user-defined Type&rsquo;.
@@ -431,6 +432,7 @@ If you wish to have several subclasses of an <el-code>abstract class</el-code> t
 <p>An <el-code>interface</el-code> may inherit only from other <el-code>interface</el-code>s.</p>
 <p>Important: An <el-code>interface</el-code> must not re-declare abstract interfaces that are defined in any <el-code>interface</el-code> it inherits from, directly or indirectly.</p>
 
+<div id="Member"></div>
 <h1 id="MemberInstructions">Member instructions</h1>
 <p>
  <a href="#constructor">constructor</a>,
@@ -506,6 +508,7 @@ If the <el-kw>property</el-kw> is not initialised within the constructor then it
 <li>A procedure method may be marked <el-code>private</el-code>, in which case it is visible only to code within the class and, if defined on an <el-code>abstract class</el-code>, within its subclasses. This is done by selecting the property frame and then pressing Ctrl-p. (Pressing these keys again will remove the <el-code>private</el-code> modifier).</li>
 </ul>
 
+<div id="FunctionMethod"></div>
 <h2 id="function_method">Function Method</h2>
 <p>A function method follows the same syntax and rules as a global <a href="#function">function</a>. The differences are:</p>
 <ul>
@@ -525,6 +528,7 @@ If the <el-kw>property</el-kw> is not initialised within the constructor then it
 <h2 id="abstractFunctionMethod">Abstract Function Method</h2>
 <p>An abstract function method may be defined only on an <a href="#abstractclass"><el-code>abstract class</el-code></a>. Any concrete subclass must then implement a concrete (regular) function to match.</p>
 
+<div id="statement"></div>
 <h1 id="StatementInstructions">Statement instructions</h1>
 <p>
  <a href="#assert">assert</a>,
@@ -557,6 +561,8 @@ by <a href="#throw">throwing an exception</a> like this:</p>
 </el-statement>
 <p>which will stop the program and print the message in the Debug window (unless caught by a <a href="#try"><el-kw>try</el-kw></a> statement).</p>
 
+<div id="Parameter_passing_1"></div>
+<div id="parameter"></div>
 <h2 id="call">Procedure call</h2>
 <p>A <el-kw>call</el-kw> statement is used when you want to run a <a href="#procedure">procedure</a>.</p>
 <p>The procedure may be:</p>
@@ -756,6 +762,7 @@ and the initial value is given by a following expression. For example:</p>
 </ul>
 <p>which this chapter describes.</p>
 
+<div id="literal_value"></div>
 <h2 id="LiteralValue">Literal value</h2>
 <p>A literal value is where a value is written &lsquo;literally&rsquo; in the code, such as <el-code>3.142</el-code> &ndash; in contrast to a value that is referred to by a name.</p>
 <p>Here is a table showing some example literal values.  Follow the links for more information about each type.</p>
@@ -776,9 +783,10 @@ For more about ListImmutable and DictionaryImmutable literals see the <a href="L
 
 <h2 id="named_value">Named value</h2>
 <p>A named value is a value that is associated with a name rather than being defined literally in code. There are various kinds of named value:</p>
-<p><a href="#constant">Constants</a>, <span class="Hyperlink"><a href="#Let_statement_1">let</a></span> statement, <span class="Hyperlink"><a href="#Variables">variable</a></span> statement, <a href="#Parameter_passing_1">Parameter passing</a>, <span class="Hyperlink"><a href="#Enum_1">enum</a></span> statement.
+<p><a href="#constant">Constants</a>, <span class="Hyperlink"><a href="#let">let</a></span> statement, <span class="Hyperlink"><a href="#variable">variable</a></span> statement, <a href="#Parameter_passing_1">Parameter passing</a>, <span class="Hyperlink"><a href="#enum">enum</a></span> statement.
   Once a named value has been defined, it can be referred to by the name.</p>
 
+<div id="parse_name"></div>
 <div id="identifier"></div><!-- Make both of these spellings work for the moment -->
 <h2 id="Identifier">Identifier</h2>
 <p>For all kinds of named values, the name must follow the rules for an &lsquo;identifier&rsquo;.
@@ -793,6 +801,7 @@ For more about ListImmutable and DictionaryImmutable literals see the <a href="L
 <p>Elan allows local named values to be defined with the same name as a constant, function, or procedure defined at global level or defined in the standard library. In such cases, when the name is used within the same method, then it will refer to the local definition. If you have done this, but then need to access the <el-code>constant</el-code>, <el-code>function</el-code>, or <el-code>procedure</el-code> with the same name, then you can simply prefix the use of the name with a &lsquo;qualifier&rsquo; of either <el-code>global.</el-code> or <el-code>library.</el-code> as appropriate.</p>
 
 <div id="range"></div>
+<div id="IndexedValue"></div>
 <h2 id="IndexedValues">Indexed values</h2>
 If a variable is of an indexable Type, then an index or index range may be applied to the variable within an expression. For example:
 <pre>
@@ -821,6 +830,7 @@ Writing a value to a specific index location is done through a method such as in
     <el-code>withPut</el-code>  on a    <el-code>DictionaryImmutable</el-code>
 </pre>
 
+<div id="operator"></div>
 <h2 id="Operators">Operators</h2>
 
 <h4 class="no-TOC" id="ArithmeticOperators">Arithmetic operators</h4>
@@ -992,6 +1002,7 @@ be followed by a 'with clause` in order to specify any property values. Example 
 
 <div id="copy"></div>
 <div id="with"></div>
+<div id="copyWith"></div>
 <h2 id="copy_with">Copy with</h2>
 <p>A 'copy with' expression is used to make a copy of an existing instance, but with a different value for one or more of the properties
   &ndash; either to assign to a named value, or as part of a more complex expression..
@@ -1046,7 +1057,7 @@ Rather, a comment contains information <em>about</em> the program, intended to b
 a comment may contain any text, except that it must not start with the open square bracket symbol '<el-code>[</el-code>'.</p>
 <p>Comments may be inserted at any level: in the <a href="#GlobalInstructions">Global</a>,
 <a href="#MemberInstructions">Member</a>, or <a href="#StatementInstructions">Statement</a> instruction levels,
-as well a from the <el-code>new code</el-code> selector, i.e. every <a href="IDEguide.html#Selector">selector</a> provides a <el-code>#</el-code> for entering a comment.</p>
+as well a from the <el-code>new code</el-code> selector, i.e. every <a href="IDEGuide.html#Selector">selector</a> provides a <el-code>#</el-code> for entering a comment.</p>
 <p> Every Elan program has a single comment at the top of the file, which is generated by the system and cannot be edited or deleted by the user.
   This comment is known as the 'file header' and shows the version of Elan being run.</p>
 
@@ -1143,6 +1154,8 @@ as well a from the <el-code>new code</el-code> selector, i.e. every <a href="IDE
  reassigned within the procedure. Therefore you must pass in a variable that can be re-assigned. You cannot pass in: a
  constant, a literal value, or a named value that is defined by a <el-kw>let</el-kw> instruction.</p>
 
+<div id="ExtensionFunction"></div>
+<div id="ExtensionProcedure"></div>
 <h3 id="ExtensionCompileError" class="no-TOC">Cannot call extension method directly</h3>
  <p>A method that is defined within the Library as an 'extension method', such as <el-method>asString</el-method> may only be called using 'dot syntax' on a named
  value or an expression.</p>
@@ -1346,6 +1359,7 @@ as well a from the <el-code>new code</el-code> selector, i.e. every <a href="IDE
 <el-type>List</el-type>&lt;<el-kw>of</el-kw> <el-type>Int</el-type>&gt;<br>
 <el-type>Dictionary</el-type>&lt;<el-kw>of</el-kw> <el-type>String</el-type>, <el-type>Int</el-type>&gt;
 
+<div id="parse_type"></div>
 <h3 id="TypeNameField" class="no-TOC">'Name' field in a class or enum definition</h3>
  <p>Type names always begin with a capital letter,  optionally followed by letters of either case, numeric digits,
  or underscore symbols. Nothing else.</p>

--- a/src/documentation/LibRef.html
+++ b/src/documentation/LibRef.html
@@ -350,6 +350,10 @@ Instead, you use the constants <el-code><el-id>quotes</el-id></el-code>, <el-cod
 <p><el-code>print "Here are the curly braces: {unicode(123)} and {unicode(125)}"</el-code></p>
 <p><el-code>print "This is an ASCII double quotation mark: " + unicode(0x22)</el-code></p>
 
+<h3 class="no-TOC" id="CharacterSets">Character Sets</h3>
+<p>Any character except quote and control characters can be used in a String.
+<a href="LangRef.html#Identifier">Identifiers</a> can only contain letters (without accents), numbers and underscore.</p>
+
 <h2 id="Tuple">Tuple</h2>
 A <el-code>tuple</el-code> is a way of holding a small number of values of different Types together as a single reference. It may be considered a lightweight alternative to defining a specific class for some purposes. Tuples are referred to as 2-tuples, 3-tuples, etc. according to the number of values they hold. Common uses include:
 <ul>
@@ -1636,8 +1640,6 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
   <td></td>
  </tr>
 </table>
-</body>
-</html>
 
 <h4 class="no-TOC">Notes</h4>
 <ul>
@@ -1807,6 +1809,7 @@ You can still insert, delete or change elements in a <el-code>ListImmutable</el-
 <p>or you could make the code offer the user options: to save again, or to continue without saving.</p>
 </ul>
 
+<div id="DisplayHtml"></div>
 <div id="displayHtml"></div>
 <h2 id="Html">Displaying Html</h2>
 <p>If you attempt to embed Html in a string and then attempt to print it, you will see the string displayed literally - the Html tags
@@ -2020,7 +2023,7 @@ So for example the top left corner of the display is at (-100,75).</p>
   <td><el-type>Float</el-type></td>
   <td>the direction in which the turtle is pointing<br>in degrees clockwise from North</td>
   <td>0.0 degrees,<br>i.e. upward in the Display</td>
-  <tr id="x_Turtle">
+ </tr><tr id="x_Turtle">
   <td><el-method>x</el-method></td>
   <td><el-type>Float</el-type></td>
   <td>the x-coordinate of the turtle's current position</td>
@@ -2054,7 +2057,7 @@ So for example the top left corner of the display is at (-100,75).</p>
  <li>If the turtle is placed or moved outside the 200 &times; 150 area boundary, it will not cause an error,
   but the location of the turtle and any lines outside the boundary will not be visible.</li>
  <li>You can move and turn the turtle, causing lines to be drawn, whether or not the turtle is shown.</li>
- <li id="heading">The current location and heading of the turtle may be read using the properties
+ <li>The current location and heading of the turtle may be read using the properties
   <el-code><el-id>x</el-id></el-code>, <el-code><el-id>y</el-id></el-code>, and <el-code><el-id>heading</el-id></el-code>.</li>
 <li>The turtle starts facing upwards (<el-id>heading</el-id> 0), so that <el-method>move</el-method> moves in the y-direction.</li>
 </ul>
@@ -2104,13 +2107,13 @@ So for example the top left corner of the display is at (-100,75).</p>
  <li id="CircleVG"> <el-code>CircleVG</el-code> for &lt;<el-code>circle../&gt;</el-code></li>
  <li id="LineVG"><el-code>LineVG</el-code> for <el-code>&lt;line../&gt;</el-code></li>
  <li id="RectangleVG"><el-code>RectangleVG</el-code> for <el-code>&lt;rect../&gt;</el-code></li>
- <li id="ImageVG"><el-code>ImageVG</el-code> for <el-code>&lt;image../&gt;</el-code></li>
+ <li id="ImageVG"><span id="imageVG"></span><el-code>ImageVG</el-code> for <el-code>&lt;image../&gt;</el-code></li>
 </ul>
 <p>The properties of the Elan shapes reflect the names of the attributes used in the SVG tags but some differ. For example, SVG's <el-code>stroke-width</el-code>
  is set with property  <el-code>strokeWidth</el-code>, to make it a valid Elan <a href="LangRef.html#identifier">Identifier</a>.
 Also <el-code>stroke</el-code> and <el-code>fill</el-code> are set by the properties <el-code>strokeColour</el-code> and <el-code>fillColour</el-code>.</p>
-<p>Vector graphics are output to the Display pane in the user interface.
-<p>The area is 100 units wide by 75 units high, and both integer and floating point values of the units can be used.<p>
+<p>Vector graphics are output to the Display pane in the user interface.</p>
+<p>The area is 100 units wide by 75 units high, and both integer and floating point values of the units can be used.</p>
 <p>The origin for SVG units (0,0) is a the top left corner of the display: positive x rightwards, positive y downwards.
 So for exxample the centre of the display is at (50, 37.5).</p>
 <p>As with using SVG from Html, the shapes are drawn in the order in which they are added to the <el-type>VectorGraphic</el-type> instance:
@@ -2301,7 +2304,7 @@ are shown below the table of properties.</p>
    allowing you to make multiple changes before updating the display. Similarly, the method to add a shape returns a new instance of the <el-code>VectorGraphics</el-code> which must be assigned either to an existing variable, or to a new <el-kw>let</el-kw>.</li>
  <li>The <el-code><el-id>fillColour</el-id></el-code> and <el-code><el-id>strokeColour</el-id></el-code> properties may be specified as described under <a href="#Colours">Colours</a>.
   The <el-code><el-id>fillColour</el-id></el-code> only may also be specified as <el-code><el-id>transparent</el-id></el-code> (which has the value <el-code>-1</el-code>).</li>
- <li><el-type>VectorGraphic</el-type> is the abstract superclass of all <el-code>...VG</el-code> shapes. You use it if you want to define a <el-type>List</el-type> holding different types of shape.</li>
+ <li id="VectorGraphic"><el-type>VectorGraphic</el-type> is the abstract superclass of all <el-code>...VG</el-code> shapes. You use it if you want to define a <el-type>List</el-type> holding different types of shape.</li>
  <li>To make it easier for simple programs, the VectorGraphic shapes all have default values for their properties, and you only have to specify the ones that you want to differ.
 So the constructors do not take any properties, and instead you add a <el-kw>with</el-kw> clause listing those properties which you want to have different values.  See <a href="LangRef.html#new">New instance</a> for more about <el-kw>with</el-kw> clauses.</li>
  <li>Individual properties of any of the VG Types may be modified by calling the corresponding <el-method>set...</el-method> procedure method
@@ -2435,6 +2438,7 @@ just as you would specify the Type of every parameter and the return Type for th
     using the same 'RGB' format as used in Html style, for example <el-code>0xff0000</el-code> for red.</li>
 </ul>
 
+<div id="LibraryProcedures"></div>
 <h1 id="StandaloneFunctions">Standalone functions</h1>
     <p>Standalone library functions always return a value and are therefore used in contexts that expect a value, such as in the right-hand side of a <el-kw>variable</el-kw> declaration or a <el-kw>set</el-kw> assignment, either on their own or within a more complex expression. All standalone library functions require at least one argument to be passed in brackets, corresponding to the parameters defined for that function.</p>
 
@@ -2867,7 +2871,7 @@ of integer values as defined by the two (integer) parameters: <el-code><el-id>st
 
 <h2 id="ref">Passing a function as a reference</h2>
 <p>To use a higher-order function (HoF), you have to pass in a reference to a function.
-This can be either a <a href="#lambda"><el-kw>lambda</el-kw></a> or the keyword <el-kw>ref</el-kw> followed by the name of a function.</p>
+This can be either a <a href="LangRef.html#lambda"><el-kw>lambda</el-kw></a> or the keyword <el-kw>ref</el-kw> followed by the name of a function.</p>
 <p>It is also possible to use references to functions not in the context of HoFs.</p>
 <p>On most occasions when you write the name of an existing function elsewhere in code your intent is to <i>evaluate</i> the function and, to do so, you write the name of the function followed by brackets containing such arguments as are required by the function. For this reason if you forget to add the brackets, you will get an error, for example:</p>
 <p><el-code>To evaluate function 'myfunction' add brackets. Or to create a reference to 'myfunction', precede it by 'ref'.</el-code></p>


### PR DESCRIPTION
Fixing links by adjusting href's and/or id's.
In some cases I have added `<div id="whatever"></div>` to LangRef or LibRef so that it works with more than one alternative id rather than changing existing ids, to guarantee that it doesn't break any existing links. This can be tidied up later if thought worth it.
I have left some of the entries red in ElanIndex.html even though they do now lead somewhere, because the text that they lead to is not comprehensive enough and needs to be revisited.
I made two links go to Concepts.html as there is really no suitable text in LangRef and LibRef and added some id's to Concepts.html. I added a brief "Character Sets" section to LibRef so there is somewhere for the link to go.
I deleted a few obsolete entries from ElanIndex: min, withPutKey, withRemoveAtKey, and added a note re TextVG
Also some HTML tag mismatch fixes!