### PR TITLE
AboutElan.html #1557 change non-ASCII ouml chars to named entities

### DIFF
--- a/src/documentation/AboutElan.html
+++ b/src/documentation/AboutElan.html
@@ -48,7 +48,7 @@
 <p>Elan was conceived by <a href="https://www.linkedin.com/in/richardpawson">Richard Pawson</a> in May 2023.
     The original design & development team consisted of Richard, Stefano Cascarini (lead technical developer), and John Stout.
     From the outset we have sought regular input and feedback from recognised experts in computer science education including:
-    <a href="https://www.kcl.ac.uk/people/michael-kolling">Michael Kölling</a> and <a href="https://simon.peytonjones.org/">Simon Peyton Jones.</a>
+    <a href="https://www.kcl.ac.uk/people/michael-kolling">Michael K&ouml;lling</a> and <a href="https://simon.peytonjones.org/">Simon Peyton Jones.</a>
     We are also reliant on volunteers to test the prototypes, write example programs, and assist with documentation and resources.
     In particular, we would like to thank: Nela Brockington, Charles Wicksteed, and Bernard Boase for regular help of this kind.
     If you are willing to assist in any way please get in touch...
@@ -86,7 +86,7 @@ as this will ensure that you are always using the latest release.</p>
 
 <p>There are very good arguments as to why the requirements for a good educational language
     are different to those for a good professional language. See, for example,
-    <a href="https://infedu.vu.lt/journal/INFEDU/article/797/info">Principles of Educational Programming Language Design</a> by Michael Kölling,
+    <a href="https://infedu.vu.lt/journal/INFEDU/article/797/info">Principles of Educational Programming Language Design</a> by Michael K&ouml;lling,
     Informatics in Education Volume 23, Issue 4 (2024). In addition to those arguments, we suggest:</p>
 
     <ul>


### PR DESCRIPTION
Changed two o-with-umlaut characters to `&ouml;` in preparation for removing the charset meta tag from all files.