### PR TITLE
Accordion css, and standalone function `sequence`

### DIFF
--- a/src/documentation/ElanIndex.html
+++ b/src/documentation/ElanIndex.html
@@ -19,55 +19,55 @@
 <tr style="text-align:center" ><th  class="sorttable_nosort" style="text-align:center">Term</th><th class="sorttable_nosort">&nbsp;&nbsp;Category&nbsp;&nbsp;</th>
 <th class="sorttable_nosort" style="text-align:center">Links</th></tr>
 <tr id="A" class="subhead"><td colspan="3">A &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>abs</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#abs">abs</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-kw>abstract</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#abstractclass">Abstract Class</a> and <a href="LangRef.html#interface">Interface</a></td></tr>
+<tr><td><el-method>abs</el-method></td><td>method</td><td>see <a href="LibRef.html#abs">abs</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>abstract</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#abstractclass">Abstract Class</a> and <a href="LangRef.html#interface">Interface</a></td></tr>
 <tr><td>Abstract class</td><td>topic</td><td>see <a href="LangRef.html#abstractclass">Abstract class</a></td></tr>
 <tr><td>Abstract function</td><td>topic</td><td>see <a href="LangRef.html#abstractfunction">Abstract function</a></td></tr>
 <tr><td>Abstract function method</td><td>topic</td><td>see <a href="LangRef.html#abstractFunctionMethod">Abstract Function Method</a></td></tr>
 <tr><td>Abstract procedure</td><td>topic</td><td>see <a href="LangRef.html#abstractprocedure">Abstract procedure</a></td></tr>
 <tr><td>Abstract procedure method</td><td>topic</td><td>see <a href="LangRef.html#AbstractProcedureMethod">Abstract Procedure Method</a></td></tr>
 <tr><td>Abstract property</td><td>topic</td><td>see <a href="LangRef.html#abstractproperty">Abstract property</a></td></tr>
-<tr><td><el-code><el-method>acos</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#acos">acos</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>acosDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#acosDeg">acosDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>add</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#add">add</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-method>addFromList</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#addFromList">addFromList</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-kw>and</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#and">and</a> in <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
-<tr><td><el-code><el-method>append</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#append">append</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>appendList</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#appendList">appendList</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>acos</el-method></td><td>method</td><td>see <a href="LibRef.html#acos">acos</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>acosDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#acosDeg">acosDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>add</el-method></td><td>method</td><td>see <a href="LibRef.html#add">add</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>addFromList</el-method></td><td>method</td><td>see <a href="LibRef.html#addFromList">addFromList</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-kw>and</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#and">and</a> in <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
+<tr><td><el-method>append</el-method></td><td>method</td><td>see <a href="LibRef.html#append">append</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>appendList</el-method></td><td>method</td><td>see <a href="LibRef.html#appendList">appendList</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td>Argument</td><td>topic</td><td>see <a href="LangRef.html#Argument">Argument</a></td></tr>
 <tr><td>Arithmetic operator</td><td>topic</td><td>see <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
-<tr><td><el-code><el-type>Array</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Array">Array</a></td></tr>
-<tr><td><el-code><el-type>Array2D</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Array2D">Array2D</a></td></tr>
-<tr><td><el-code><el-kw>as</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#as">as</a> in <a href="LangRef.html#Parameters">Parameters</a></td></tr>
-<tr><td><el-code><el-method>asBinary</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asBinary">asBinary</a> in <a href="LibRef.html#Int">Integer</a></td></tr>
+<tr><td><el-type>Array</el-type></td><td>Type</td><td>see <a href="LibRef.html#Array">Array</a></td></tr>
+<tr><td><el-type>Array2D</el-type></td><td>Type</td><td>see <a href="LibRef.html#Array2D">Array2D</a></td></tr>
+<tr><td><el-kw>as</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#as">as</a> in <a href="LangRef.html#Parameters">Parameters</a></td></tr>
+<tr><td><el-method>asBinary</el-method></td><td>method</td><td>see <a href="LibRef.html#asBinary">asBinary</a> in <a href="LibRef.html#Int">Integer</a></td></tr>
 <tr><td>ASCII</td><td>topic</td><td>see <a href="LibRef.html#CharacterSets">Character sets</a></td></tr>
-<tr><td><el-code><el-method>asin</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asin">asin</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>asinDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asinDeg">asinDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>asList</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>asListImmutable</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asListImmutable">asListImmutable</a> in <a href="LibRef.html#ListImmutable">List immutable</a></td></tr>
-<tr><td><el-code><el-method>asRegExp</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asRegExp">asRegExp</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-kw>assert</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#assert">Assert statement</a></td></tr>
-<tr><td><el-code><el-method>asSet</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-method>asString</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>asUnicode</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#asUnicode">asUnicode</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>atan</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#atan">atan</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>atanDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#atanDeg">atanDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>asin</el-method></td><td>method</td><td>see <a href="LibRef.html#asin">asin</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>asinDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#asinDeg">asinDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>asList</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>asListImmutable</el-method></td><td>method</td><td>see <a href="LibRef.html#asListImmutable">asListImmutable</a> in <a href="LibRef.html#ListImmutable">List immutable</a></td></tr>
+<tr><td><el-method>asRegExp</el-method></td><td>method</td><td>see <a href="LibRef.html#asRegExp">asRegExp</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-kw>assert</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#assert">Assert statement</a></td></tr>
+<tr><td><el-method>asSet</el-method></td><td>method</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>asString</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>asUnicode</el-method></td><td>method</td><td>see <a href="LibRef.html#asUnicode">asUnicode</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>atan</el-method></td><td>method</td><td>see <a href="LibRef.html#atan">atan</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>atanDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#atanDeg">atanDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
 <tr id="B" class="subhead"><td colspan="3">B &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-kw>be</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#let">Let statement</a></td></tr>
-<tr><td><el-code><el-method>bitAnd</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitAnd">bitAnd</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
-<tr><td><el-code><el-method>bitNot</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitNot">bitNot</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
-<tr><td><el-code><el-method>bitOr</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitOr">bitOr</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a>
+<tr><td><el-kw>be</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#let">Let statement</a></td></tr>
+<tr><td><el-method>bitAnd</el-method></td><td>method</td><td>see <a href="LibRef.html#bitAnd">bitAnd</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
+<tr><td><el-method>bitNot</el-method></td><td>method</td><td>see <a href="LibRef.html#bitNot">bitNot</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
+<tr><td><el-method>bitOr</el-method></td><td>method</td><td>see <a href="LibRef.html#bitOr">bitOr</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a>
 </td></tr>
-<tr><td><el-code><el-method>bitShiftL</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitShiftL">bitShiftL</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
-<tr><td><el-code><el-method>bitShiftR</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitShiftR">bitShiftR</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
+<tr><td><el-method>bitShiftL</el-method></td><td>method</td><td>see <a href="LibRef.html#bitShiftL">bitShiftL</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
+<tr><td><el-method>bitShiftR</el-method></td><td>method</td><td>see <a href="LibRef.html#bitShiftR">bitShiftR</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
 <tr><td>Bitwise functions</td><td>topic</td><td>see <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
-<tr><td><el-code><el-method>bitXor</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#bitXor">bitXor</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
-<tr><td><el-code><el-id>black</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-method>bitXor</el-method></td><td>method</td><td>see <a href="LibRef.html#bitXor">bitXor</a> in <a href="LibRef.html#BitwiseFunctions">Bitwise functions</a></td></tr>
+<tr><td><el-id>black</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr><td>Block graphics</td><td>topic</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
-<tr><td><el-code><el-id>blue</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-type>Boolean</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Boolean">Boolean</a></td></tr>
+<tr><td><el-id>blue</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-type>Boolean</el-type></td><td>Type</td><td>see <a href="LibRef.html#Boolean">Boolean</a></td></tr>
 <tr><td>Breakpoint</td><td>IDE</td><td>see <a href="IDEGuide.html#Breakpoint">Breakpoints</a></td></tr>
-<tr><td><el-code><el-id>brown</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-id>brown</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr><td>Button +/- </td><td>IDE</td><td>see <a href="IDEGuide.html#ButtonOutlining">Outlining</a></td></tr>
 <tr><td>Button Clear display</td><td>IDE</td><td>see <a href="IDEGuide.html#ButtonClearDisplay">Run controls</a></td></tr>
 <tr><td>Button Debug<img src="images/Debug.png" style="width:20px; height:20px; float:right;"></td><td>IDE</td><td>see <a href="IDEGuide.html#RunControls">Run controls</a></td></tr>
@@ -82,311 +82,312 @@
 <tr><td>Button Trim</td><td>IDE</td><td>see <a href="IDEGuide.html#ButtonTrim">Trim</a></td></tr>
 <tr><td>Button Undo</td><td>IDE</td><td>see <a href="IDEGuide.html#ButtonUndo">Undo</a></td></tr>
 <tr id="C" class="subhead"><td colspan="3">C &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-kw>call</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#call">Procedure call</a></td></tr>
-<tr><td><el-code><el-kw>catch</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#try">Try statement</a></td></tr>
-<tr><td><el-code><el-method>ceiling</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#ceiling">ceiling</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>call</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#call">Procedure call</a></td></tr>
+<tr><td><el-kw>catch</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#try">Try statement</a></td></tr>
+<tr><td><el-method>ceiling</el-method></td><td>method</td><td>see <a href="LibRef.html#ceiling">ceiling</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
 <tr><td>Character sets</td><td>topic</td><td>see <a href="LibRef.html#CharacterSets">Character sets</a></td></tr>
-<tr><td><el-code><el-type>CircleVG</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#CircleVG">circleVG</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-kw>Class</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#class">Class</a></td></tr>
-<tr><td><el-code><el-method>clearAndReset</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#clearAndReset">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>clearPrintedText</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#clearPrintedText">clearPrintedText</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
-<tr><td><el-code><el-method>clearKeyBuffer</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#clearKeyBuffer">clearKeyBuffer</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
-<tr><td><el-code><el-method>clock</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#clock">clock</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>close</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#close">close</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-id>closeBrace</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#closeBrace">String constants</a></td></tr>
+<tr><td><el-type>CircleVG</el-type></td><td>Type</td><td>see <a href="LibRef.html#CircleVG">circleVG</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-kw>Class</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#class">Class</a></td></tr>
+<tr><td><el-method>clearAndReset</el-method></td><td>method</td><td>see <a href="LibRef.html#clearAndReset">Turtle graphics</a></td></tr>
+<tr><td><el-method>clearPrintedText</el-method></td><td>method</td><td>see <a href="LibRef.html#clearPrintedText">clearPrintedText</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
+<tr><td><el-method>clearKeyBuffer</el-method></td><td>method</td><td>see <a href="LibRef.html#clearKeyBuffer">clearKeyBuffer</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
+<tr><td><el-method>clock</el-method></td><td>method</td><td>see <a href="LibRef.html#clock">clock</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>close</el-method></td><td>method</td><td>see <a href="LibRef.html#close">close</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-id>closeBrace</el-id></td><td>constant</td><td>see <a href="LibRef.html#closeBrace">String constants</a></td></tr>
 <tr><td>Colours</td><td>topic</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr><td>Comment #</td><td>topic</td><td>see <a href="LangRef.html#Comment"># Comments</a></td></tr>
 <tr><td>Compilation</td><td>topic</td><td>see <a href="IDEGuide.html#StatusPanel">Status panel</a></td></tr>
 <tr><td>Compile errors</td><td>topic</td><td>see <a href="LangRef.html#compile_error">Compile Errors and Warnings</a></td></tr>
-<tr><td><el-code><el-kw>constant</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#constant">constant</a> and <a href="LibRef.html#Constants">Library constants</a></td></tr>
+<tr><td><el-kw>constant</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#constant">constant</a> and <a href="LibRef.html#Constants">Library constants</a></td></tr>
 <tr><td>Constants</td><td>topic</td><td>see <a href="LibRef.html#Constants">Library constants</a></td></tr>
-<tr><td><el-code><el-kw>constructor</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#constructor">Constructor</a></td></tr>
+<tr><td><el-kw>constructor</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#constructor">Constructor</a></td></tr>
 <tr><td>Container instruction</td><td>IDE</td><td>see <a href="IDEGuide.html#ContainerInstruction">Code editor</a></td></tr>
-<tr><td><el-code><el-method>contains</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>contains</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
 <tr><td>Context menu</td><td>IDE</td><td>see <a href="IDEGuide.html#ContextMenu">Context menu</a></td></tr>
-<tr><td><el-code><el-kw>copy</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#copyWith">Copy with</a></td></tr>
-<tr><td><el-code><el-method>cos</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#cos">cos</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>cosDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#cosDeg">cosDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>createFileForWriting</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#createFileForWriting">createFileForWriting</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-kw>copy</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#copyWith">Copy with</a></td></tr>
+<tr><td><el-method>cos</el-method></td><td>method</td><td>see <a href="LibRef.html#cos">cos</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>cosDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#cosDeg">cosDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>createFileForWriting</el-method></td><td>method</td><td>see <a href="LibRef.html#createFileForWriting">createFileForWriting</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr><td>CSS</td><td>topic</td><td>see <a href="LibRef.html#displayHtml">Displaying Html</a></td></tr>
 <tr id="D" class="subhead"><td colspan="3">D &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>degToRad</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#degToRad">degToRad</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>dequeue</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#dequeue">dequeue</a> in <a href="LibRef.html#QueueFunctions">Queue functions</a></td></tr>
-<tr><td><el-code><el-type>Dictionary</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
-<tr><td><el-code><el-type>DictionaryImmutable</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#DictionaryImmutable">DictionaryImmutable</a></td></tr>
-<tr><td><el-code><el-method>difference</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#difference">difference</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>degToRad</el-method></td><td>method</td><td>see <a href="LibRef.html#degToRad">degToRad</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>dequeue</el-method></td><td>method</td><td>see <a href="LibRef.html#dequeue">dequeue</a> in <a href="LibRef.html#QueueFunctions">Queue functions</a></td></tr>
+<tr><td><el-type>Dictionary</el-type></td><td>Type</td><td>see <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
+<tr><td><el-type>DictionaryImmutable</el-type></td><td>Type</td><td>see <a href="LibRef.html#DictionaryImmutable">DictionaryImmutable</a></td></tr>
+<tr><td><el-method>difference</el-method></td><td>method</td><td>see <a href="LibRef.html#difference">difference</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
 <tr><td>Display</td><td>IDE</td><td>see <a href="IDEGuide.html#Display">Display</a></td></tr>
-<tr><td><el-code><el-method>displayBlocks</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
-<tr><td><el-code><el-method>displayHtml</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#displayHtml">Displaying Html</a></td></tr>
-<tr><td><el-code><el-method>displayVectorGraphics</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-kw>div</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#div">div</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
+<tr><td><el-method>displayBlocks</el-method></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
+<tr><td><el-method>displayHtml</el-method></td><td>method</td><td>see <a href="LibRef.html#displayHtml">Displaying Html</a></td></tr>
+<tr><td><el-method>displayVectorGraphics</el-method></td><td>method</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-kw>div</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#div">div</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
 <tr class="x"><td>Dot method</td><td>topic</td><td>see <a href="Concepts.html#DotMethods">Dot methods</a></td></tr>
 <tr id="E" class="subhead"><td colspan="3">E &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-kw>each</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#each">Each loop</a></td></tr>
+<tr><td><el-kw>each</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#each">Each loop</a></td></tr>
 <tr><td>Editor</td><td>IDE</td><td>see <a href="IDEGuide.html#Editor">Code editor</a></td></tr>
-<tr><td><el-code><el-kw>else</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
-<tr><td><el-code><el-kw>empty</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#empty">Empty of Type</a></td></tr>
-<tr class="x"><td><el-code><el-kw>end</el-kw></el-code></td><td>keyword</td><td>Automatically supplied at end of program constructs</td></tr>
-<tr><td><el-code><el-method>endOfFile</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#endOfFile">endOfFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-method>enqueue</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#enqueue">enqueue</a> in <a href="LibRef.html#QueueFunctions">Queue functions</a></td></tr>
-<tr><td><el-code><el-kw>enum</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#enum">Enum</a></td></tr>
+<tr><td><el-kw>else</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
+<tr><td><el-kw>empty</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#empty">Empty of Type</a></td></tr>
+<tr class="x"><td><el-kw>end</el-kw></td><td>keyword</td><td>Automatically supplied at end of program constructs</td></tr>
+<tr><td><el-method>endOfFile</el-method></td><td>method</td><td>see <a href="LibRef.html#endOfFile">endOfFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-method>enqueue</el-method></td><td>method</td><td>see <a href="LibRef.html#enqueue">enqueue</a> in <a href="LibRef.html#QueueFunctions">Queue functions</a></td></tr>
+<tr><td><el-kw>enum</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#enum">Enum</a></td></tr>
 <tr><td>Equality testing</td><td>topic</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
-<tr><td><el-code><el-kw>exception</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#throw">Throw</a> and <a href="LangRef.html#try">Try</a> statements</td></tr>
-<tr><td><el-code><el-method>exp</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#exp">exp</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>exception</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#throw">Throw</a> and <a href="LangRef.html#try">Try</a> statements</td></tr>
+<tr><td><el-method>exp</el-method></td><td>method</td><td>see <a href="LibRef.html#exp">exp</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
 <tr><td>Expression</td><td>topic</td><td>see <a href="LangRef.html#Expression">Expressions</a></td></tr>
 <tr class="x"><td>Extension function</td><td>topic</td><td>see <a href="LangRef.html#ExtensionFunction">Extension function</a></td></tr>
 <tr class="x"><td>Extension procedure</td><td>topic</td><td>see <a href="LangRef.html#ExtensionProcedure">Extension procedure</a></td></tr>
 <tr id="F" class="subhead"><td colspan="3">F &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-id>false</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#false">Boolean constants</a></td></tr>
+<tr><td><el-id>false</el-id></td><td>constant</td><td>see <a href="LibRef.html#false">Boolean constants</a></td></tr>
 <tr><td>Field</td><td>IDE</td><td>see <a href="IDEGuide.html#Field">Fields</a></td></tr>
 <tr><td>File input/output</td><td>topic</td><td>see <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-method>fill</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-method>filter</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#filter">filter</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-type>Float</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Float">Floating point</a></td></tr>
-<tr><td><el-code><el-method>floor</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#floor">floor</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-kw>for</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
-<tr><td><el-code><el-kw>from</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
-<tr><td><el-code><el-type>Func</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Func">Func</a></td></tr>
-<tr><td><el-code><el-kw>function</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#function">function</a></td></tr>
+<tr><td><el-method>fill</el-method></td><td>method</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-method>filter</el-method></td><td>method</td><td>see <a href="LibRef.html#filter">filter</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-type>Float</el-type></td><td>Type</td><td>see <a href="LibRef.html#Float">Floating point</a></td></tr>
+<tr><td><el-method>floor</el-method></td><td>method</td><td>see <a href="LibRef.html#floor">floor</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>for</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
+<tr><td><el-kw>from</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
+<tr><td><el-type>Func</el-type></td><td>Type</td><td>see <a href="LibRef.html#Func">Func</a></td></tr>
+<tr><td><el-kw>function</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#function">function</a></td></tr>
 <tr><td>Function call</td><td>topic</td><td>see <a href="LangRef.html#function_call">Function call</a></td></tr>
 <tr><td>Function method</td><td>topic</td><td>see <a href="LangRef.html#FunctionMethod">Function method</a></td></tr>
 <tr><td>Functional programming</td><td>topic</td><td>see <a href="Functional_Programming.html#top">Functional programming</a></td></tr>
 <tr id="G" class="subhead"><td colspan="3">G &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>getBackground</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
-<tr><td><el-code><el-method>getChar</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
-<tr><td><el-code><el-method>getForeground</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
-<tr><td><el-code><el-method>getKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#getKey">getKey</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
-<tr><td><el-code><el-method>getKeyWithModifier</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#getKeyWithModifier">getKeyWithModifier</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>getBackground</el-method></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
+<tr><td><el-method>getChar</el-method></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
+<tr><td><el-method>getForeground</el-method></td><td>method</td><td>see <a href="LibRef.html#BlockGraphics">Block graphics</a></td></tr>
+<tr><td><el-method>getKey</el-method></td><td>method</td><td>see <a href="LibRef.html#getKey">getKey</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
+<tr><td><el-method>getKeyWithModifier</el-method></td><td>method</td><td>see <a href="LibRef.html#getKeyWithModifier">getKeyWithModifier</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr><td>Global instructions</td><td>topic</td><td>see <a href="LangRef.html#GlobalInstructions">Global instructions</a></td></tr>
 <tr><td>Global prompt</td><td>IDE</td><td>see <a href="IDEGuide.html#GlobalPrompt">Global prompt</a></td></tr>
 <tr><td>Graphics</td><td>topic</td><td>see <a href="LibRef.html#BlockGraphics">Block Graphics</a>, <a href="LibRef.html#TurtleGraphics">Turtle graphics</a>, <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-id>green</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-id>grey</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-id>green</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-id>grey</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr id="H" class="subhead"><td colspan="3">H &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>hasKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#DictionaryImmutable">Dictionary immutable</a></td></tr>
-<tr><td><el-code><el-method>head</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>heading</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#heading">Turtle graphics</a></td></tr>
+<tr><td><el-method>hasKey</el-method></td><td>method</td><td>see <a href="LibRef.html#DictionaryImmutable">Dictionary immutable</a></td></tr>
+<tr><td><el-method>head</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>heading</el-method></td><td>method</td><td>see <a href="LibRef.html#heading">Turtle graphics</a></td></tr>
 <tr><td>Hexadecimal</td><td>topic</td><td>see <a href="LibRef.html#Int">Integers</a>, <a href="LibRef.html#Colours">Colours</a> and <a href="LibRef.html#unicode">Unicode</a></td></tr>
-<tr><td><el-code><el-method>hide</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#hide">Turtle graphics</a></td></tr>
+<tr><td><el-method>hide</el-method></td><td>method</td><td>see <a href="LibRef.html#hide">Turtle graphics</a></td></tr>
 <tr><td>HoF</td><td>topic</td><td>see <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
 <tr><td>HTML</td><td>topic</td><td>see <a href="LibRef.html#DisplayHtml">Displaying Html</a></td></tr>
 <tr id="I" class="subhead"><td colspan="3">I &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>IDE</td><td>IDE</td><td>see <a href="IDEGuide.html#top">Integrated Development Environment</a></td></tr>
 <tr><td>Identifier</td><td>topic</td><td>see <a href="LangRef.html#Identifier">Identifier</a></td></tr>
-<tr><td><el-code><el-kw>if</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
+<tr><td><el-kw>if</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
 <tr><td>If expression</td><td>topic</td><td>see <a href="LangRef.html#if_expression">If expression</a></td></tr>
-<tr><td><el-code><el-kw>ignore</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#ignore">Marking a test with ignore</a></td></tr>
-<tr><td><el-code><el-kw>image</el-kw></el-code></td><td>keyword</td><td>see <a href="LibRef.html#image">Displaying images</a></td></tr>
-<tr><td><el-code><el-type>ImageVG</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#imageVG">Vector graphics</a></td></tr>
-<tr><td><el-code><el-kw>in</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#each">Each loop</a></td></tr>
+<tr><td><el-kw>ignore</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#ignore">Marking a test with ignore</a></td></tr>
+<tr><td><el-kw>image</el-kw></td><td>keyword</td><td>see <a href="LibRef.html#image">Displaying images</a></td></tr>
+<tr><td><el-type>ImageVG</el-type></td><td>Type</td><td>see <a href="LibRef.html#imageVG">Vector graphics</a></td></tr>
+<tr><td><el-kw>in</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#each">Each loop</a></td></tr>
 <tr><td>Indexed value</td><td>topic</td><td>see <a href="LangRef.html#IndexedValue">Indexed Value</a></td></tr>
-<tr><td><el-code><el-method>indexOf</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>indexOf</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
 <tr><td>Inheritance</td><td>topic</td><td>see <a href="LangRef.html#Inheritance">Inheritance</a></td></tr>
-<tr><td><el-code><el-kw>inherits</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#Inheritance">Inheritance</a></td></tr>
+<tr><td><el-kw>inherits</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#Inheritance">Inheritance</a></td></tr>
 <tr><td>Input, keyboard</td><td>topic</td><td>see <a href="IDEGuide.html#Keyboard">Keyboard</a></td></tr>
 <tr><td>Input, file</td><td>topic</td><td>see <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-method>inputFloat</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputFloat">inputFloat</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputFloatBetween</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputFloatBetween">inputFloatBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputInt">inputInt</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputIntBetween</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputIntBetween">inputIntBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputString</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputString">inputString</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputStringFromOptions</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputStringFromOptions">inputStringFromOptions</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>inputStringWithLimits</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#inputStringWithLimits">inputStringWithLimits</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>insert</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#insert">insert</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>inputFloat</el-method></td><td>method</td><td>see <a href="LibRef.html#inputFloat">inputFloat</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputFloatBetween</el-method></td><td>method</td><td>see <a href="LibRef.html#inputFloatBetween">inputFloatBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputInt</el-method></td><td>method</td><td>see <a href="LibRef.html#inputInt">inputInt</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputIntBetween</el-method></td><td>method</td><td>see <a href="LibRef.html#inputIntBetween">inputIntBetween</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputString</el-method></td><td>method</td><td>see <a href="LibRef.html#inputString">inputString</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputStringFromOptions</el-method></td><td>method</td><td>see <a href="LibRef.html#inputStringFromOptions">inputStringFromOptions</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>inputStringWithLimits</el-method></td><td>method</td><td>see <a href="LibRef.html#inputStringWithLimits">inputStringWithLimits</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>insert</el-method></td><td>method</td><td>see <a href="LibRef.html#insert">insert</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td>Instance</td><td>topic</td><td>see <a href="LangRef.html#new">New instance</a></td></tr>
 <tr><td>Instruction</td><td>IDE</td><td>see <a href="IDEGuide.html#Instruction">Instructions</a></td></tr>
-<tr><td><el-code><el-type>Int</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Int">Integer</a></td></tr>
-<tr><td><el-code><el-kw>interface</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#interface">Interface</a></td></tr>
+<tr><td><el-type>Int</el-type></td><td>Type</td><td>see <a href="LibRef.html#Int">Integer</a></td></tr>
+<tr><td><el-kw>interface</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#interface">Interface</a></td></tr>
 <tr><td>Interpolated string</td><td>topic</td><td>see <a href="LibRef.html#InterpolatedString">Interpolated strings</a></td></tr>
-<tr><td><el-code><el-method>intersection</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-kw>is</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
-<tr><td><el-code><el-method>isAfter</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isAfter">isAfter</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>isAfterOrSameAs</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isAfterOrSameAs">isAfterOrSameAs</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>isBefore</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isBefore">isBefore</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>isBeforeOrSameAs</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isBeforeOrSameAs">isBeforeOrSameAs</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>isDisjointFrom</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isDisjointFrom">isDisjointFrom</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code>isInfinite</el-code></td><td>method</td><td>see <a href="LibRef.html#isInfinite">isInfinite</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code>isNaN</el-code></td><td>method</td><td>see <a href="LibRef.html#isNaN">isNaN</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-kw>isnt</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
-<tr><td><el-code><el-method>isSubsetOf</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isSubsetOf">isSubsetOf</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-method>isSupersetOf</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#isSupersetOf">isSupersetOf</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>intersection</el-method></td><td>method</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-kw>is</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
+<tr><td><el-method>isAfter</el-method></td><td>method</td><td>see <a href="LibRef.html#isAfter">isAfter</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>isAfterOrSameAs</el-method></td><td>method</td><td>see <a href="LibRef.html#isAfterOrSameAs">isAfterOrSameAs</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>isBefore</el-method></td><td>method</td><td>see <a href="LibRef.html#isBefore">isBefore</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>isBeforeOrSameAs</el-method></td><td>method</td><td>see <a href="LibRef.html#isBeforeOrSameAs">isBeforeOrSameAs</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>isDisjointFrom</el-method></td><td>method</td><td>see <a href="LibRef.html#isDisjointFrom">isDisjointFrom</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>isInfinite</el-method></td><td>method</td><td>see <a href="LibRef.html#isInfinite">isInfinite</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>isNaN</el-method></td><td>method</td><td>see <a href="LibRef.html#isNaN">isNaN</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>isnt</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
+<tr><td><el-method>isSubsetOf</el-method></td><td>method</td><td>see <a href="LibRef.html#isSubsetOf">isSubsetOf</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>isSupersetOf</el-method></td><td>method</td><td>see <a href="LibRef.html#isSupersetOf">isSupersetOf</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
 <tr id="J" class="subhead"><td colspan="3">J &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>join</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#join">join</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>join</el-method></td><td>method</td><td>see <a href="LibRef.html#join">join</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
 <tr id="K" class="subhead"><td colspan="3">K &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Keyboard</td><td>topic</td><td>see <a href="IDEGuide.html#Keyboard">Keyboard</a></td></tr>
-<tr><td><el-code><el-method>keys</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#keys">keys</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
+<tr><td><el-method>keys</el-method></td><td>method</td><td>see <a href="LibRef.html#keys">keys</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
 <tr id="L" class="subhead"><td colspan="3">L &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-kw>lambda</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#lambda">Lambda</a></td></tr>
-<tr><td><el-code><el-method>length</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-kw>let</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#let">Let statement</a></td></tr>
-<tr><td><el-code><el-type>LineVG</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#LineVG">Vector graphics</a></td></tr>
-<tr><td><el-code><el-type>ListImmutable</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#ListImmutable">ListImmutable</a></td></tr>
+<tr><td><el-kw>lambda</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#lambda">Lambda</a></td></tr>
+<tr><td><el-method>length</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-kw>let</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#let">Let statement</a></td></tr>
+<tr><td><el-type>LineVG</el-type></td><td>Type</td><td>see <a href="LibRef.html#LineVG">Vector graphics</a></td></tr>
+<tr><td><el-type>ListImmutable</el-type></td><td>Type</td><td>see <a href="LibRef.html#ListImmutable">ListImmutable</a></td></tr>
 <tr><td>Literal value</td><td>topic</td><td>see <a href="LangRef.html#literal_value">Literal value</a></td></tr>
-<tr><td><el-code><el-method>log10</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#log10">log10</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>log2</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#log2">log2</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>logE</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#logE">logE</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>log10</el-method></td><td>method</td><td>see <a href="LibRef.html#log10">log10</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>log2</el-method></td><td>method</td><td>see <a href="LibRef.html#log2">log2</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>logE</el-method></td><td>method</td><td>see <a href="LibRef.html#logE">logE</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
 <tr><td>Logical operator</td><td>topic</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
-<tr><td><el-code><el-method>lowerCase</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#lowerCase">lowerCase</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>lowerCase</el-method></td><td>method</td><td>see <a href="LibRef.html#lowerCase">lowerCase</a> in <a href="LibRef.html#String">String</a></td></tr>
 <tr id="M" class="subhead"><td colspan="3">M &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-kw>main</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#main">main</a></td></tr>
-<tr><td><el-code><el-method>map</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#map">map</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-method>matchesRegExp</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#matchesRegExp">matchesRegEx</a> in <a href="LibRef.html#String">String</a>
+<tr><td><el-kw>main</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#main">main</a></td></tr>
+<tr><td><el-method>map</el-method></td><td>method</td><td>see <a href="LibRef.html#map">map</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-method>matchesRegExp</el-method></td><td>method</td><td>see <a href="LibRef.html#matchesRegExp">matchesRegEx</a> in <a href="LibRef.html#String">String</a>
 </td></tr>
-<tr><td><el-code><el-method>maxBy</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#maxBy">maxBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-method>maxFloat</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#maxFloat">maxFloat</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>maxInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#maxInt">maxInt</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>minFloat</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minFloat">minFloat</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>minInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minInt">minInt</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>maxBy</el-method></td><td>method</td><td>see <a href="LibRef.html#maxBy">maxBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-method>maxFloat</el-method></td><td>method</td><td>see <a href="LibRef.html#maxFloat">maxFloat</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>maxInt</el-method></td><td>method</td><td>see <a href="LibRef.html#maxInt">maxInt</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>minFloat</el-method></td><td>method</td><td>see <a href="LibRef.html#minFloat">minFloat</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>minInt</el-method></td><td>method</td><td>see <a href="LibRef.html#minInt">minInt</a> in <a href="LibRef.html#List">List</a></td></tr>
 <tr><td>Member instructions</td><td>topic</td><td>see <a href="LangRef.html#MemberInstructions">Member instructions</a></td></tr>
 <tr><td>Member prompt</td><td>IDE</td><td>see <a href="IDEGuide.html#MemberPrompt">Member prompt</a></td></tr>
 <tr class="x"><td>Method</td><td>topic</td><td>see <a href="LangRef.html#Methods">Methods</a></td></tr>
-<tr><td><el-code><el-method>minBy</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#minBy">minBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-kw>mod</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#mod">mod</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
+<tr><td><el-method>minBy</el-method></td><td>method</td><td>see <a href="LibRef.html#minBy">minBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-kw>mod</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#mod">mod</a> in <a href="LangRef.html#ArithmeticOperators">Arithmetic operators</a></td></tr>
 <tr><td>Mouse</td><td>topic</td><td>see <a href="IDEGuide.html#Mouse">Mouse</a></td></tr>
-<tr><td><el-code><el-method>move</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#move">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>moveTo</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#moveTo">Turtle graphics</a></td></tr>
+<tr><td><el-method>move</el-method></td><td>method</td><td>see <a href="LibRef.html#move">Turtle graphics</a></td></tr>
+<tr><td><el-method>moveTo</el-method></td><td>method</td><td>see <a href="LibRef.html#moveTo">Turtle graphics</a></td></tr>
 <tr class="x"><td>Mutability</td><td>topic</td><td>see <a href="Concepts.html#Mutable">Mutability and immutability</a></td></tr>
 <tr id="N" class="subhead"><td colspan="3">N &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Named value</td><td>topic</td><td>see <a href="LangRef.html#named_value">Named value</a></td></tr>
-<tr><td><el-code><el-kw>new</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#new">New instance</a></td></tr>
-<tr><td><el-code><el-kw>not</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
+<tr><td><el-kw>new</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#new">New instance</a></td></tr>
+<tr><td><el-kw>not</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
 <tr><td>Numeric comparison</td><td>topic</td><td>see <a href="LangRef.html#EqualityTesting">Equality testing</a></td></tr>
 <tr id="O" class="subhead"><td colspan="3">O &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Object-oriented programming</td><td>topic</td><td>see <a href="Object-oriented_programming.html#top">Object-oriented programming</a></td></tr>
-<tr><td><el-code><el-kw>of</el-kw></el-code></td><td>keyword</td><td>see <el-code>&lt;of [Type]&gt;</el-code> in <a href="LibRef.html#StandardDataStructures">Standard data structures</a></td></tr>
-<tr><td><el-code><el-id>openBrace</el-id></el-code></td><td>constant</td><td><a href="LibRef.html#openBrace">String constants</a></td></tr>
-<tr><td><el-code><el-method>openFileForReading</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#openFileForReading">openFileForReading</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-kw>of</el-kw></td><td>keyword</td><td>see <el-code>&lt;of [Type]&gt;</el-code> in <a href="LibRef.html#StandardDataStructures">Standard data structures</a></td></tr>
+<tr><td><el-id>openBrace</el-id></td><td>constant</td><td><a href="LibRef.html#openBrace">String constants</a></td></tr>
+<tr><td><el-method>openFileForReading</el-method></td><td>method</td><td>see <a href="LibRef.html#openFileForReading">openFileForReading</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr><td>Operator</td><td>topic</td><td>see <a href="LangRef.html#operator">Operators</a></td></tr>
-<tr><td><el-code><el-kw>or</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
-<tr><td><el-code><el-kw>out</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#procedure">Procedure returned values</a></td></tr>
+<tr><td><el-kw>or</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#LogicalOperators">Logical operators</a></td></tr>
+<tr><td><el-kw>out</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#procedure">Procedure returned values</a></td></tr>
 <tr><td>Output, file</td><td>topic</td><td>see <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr id="P" class="subhead"><td colspan="3">P &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Parameter</td><td>topic</td><td>see <a href="LangRef.html#parameter">Parameters</a></td></tr>
-<tr><td><el-code><el-method>parseAsFloat</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#parseAs">parseAsFloat</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
-<tr><td><el-code><el-method>parseAsInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#parseAs">parseAsInt</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
-<tr><td><el-code><el-method>pause</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#pause">Standalone procedures</a></td></tr>
-<tr><td><el-code><el-method>peek</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>penColour</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#penColour">penColour</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a> and <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-method>penDown</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#penDown">penDown</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>penUp</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#penUp">penUp</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>penWidth</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#penWidth">penWidth</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-id>pi</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#pi">Maths constant</a></td></tr>
-<tr><td><el-code><el-method>placeAt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#placeAt">placeAt</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>pop</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#pop">pop</a> in <a href="LibRef.html#StackFunctions">Stack functions</a></td></tr>
-<tr><td><el-code><el-method>prepend</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#prepend">prepend</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>prependList</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#prependList">prependList</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-kw>print</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#print">Print statement</a></td></tr>
+<tr><td><el-method>parseAsFloat</el-method></td><td>method</td><td>see <a href="LibRef.html#parseAs">parseAsFloat</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
+<tr><td><el-method>parseAsInt</el-method></td><td>method</td><td>see <a href="LibRef.html#parseAs">parseAsInt</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
+<tr><td><el-method>pause</el-method></td><td>method</td><td>see <a href="LibRef.html#pause">Standalone procedures</a></td></tr>
+<tr><td><el-method>peek</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>penColour</el-method></td><td>method</td><td>see <a href="LibRef.html#penColour">penColour</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a> and <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-method>penDown</el-method></td><td>method</td><td>see <a href="LibRef.html#penDown">penDown</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>penUp</el-method></td><td>method</td><td>see <a href="LibRef.html#penUp">penUp</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>penWidth</el-method></td><td>method</td><td>see <a href="LibRef.html#penWidth">penWidth</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-id>pi</el-id></td><td>constant</td><td>see <a href="LibRef.html#pi">Maths constant</a></td></tr>
+<tr><td><el-method>placeAt</el-method></td><td>method</td><td>see <a href="LibRef.html#placeAt">placeAt</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>pop</el-method></td><td>method</td><td>see <a href="LibRef.html#pop">pop</a> in <a href="LibRef.html#StackFunctions">Stack functions</a></td></tr>
+<tr><td><el-method>prepend</el-method></td><td>method</td><td>see <a href="LibRef.html#prepend">prepend</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>prependList</el-method></td><td>method</td><td>see <a href="LibRef.html#prependList">prependList</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-kw>print</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#print">Print statement</a></td></tr>
 <tr><td>Printing HTML</td><td>topic</td><td>see <a href="LibRef.html#DisplayHtml">Printing HTML</a></td></tr>
-<tr><td><el-code><el-method>printLine</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#printLine">printLine</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
-<tr><td><el-code><el-method>printNoLine</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#printNoLine">printNoLine</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
-<tr><td><el-code><el-method>printTab</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#printTab">printTab</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
-<tr><td><el-code><el-kw>private</el-kw></el-code></td><td>keyword</td><td>see Private <a href="LangRef.html#property">property</a>, <a href="LangRef.html#procedure">procedure</a>
+<tr><td><el-method>printLine</el-method></td><td>method</td><td>see <a href="LibRef.html#printLine">printLine</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
+<tr><td><el-method>printNoLine</el-method></td><td>method</td><td>see <a href="LibRef.html#printNoLine">printNoLine</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
+<tr><td><el-method>printTab</el-method></td><td>method</td><td>see <a href="LibRef.html#printTab">printTab</a> in <a href="LibRef.html#LibraryProcedures">Library procedures</a></td></tr>
+<tr><td><el-kw>private</el-kw></td><td>keyword</td><td>see Private <a href="LangRef.html#property">property</a>, <a href="LangRef.html#procedure">procedure</a>
  and <a href="LangRef.html#function">function</a> </td></tr>
 <tr><td>Procedural programming</td><td>topic</td><td>see <a href="Procedural_programming.html#top">Procedural programming</a></td></tr>
-<tr><td><el-code><el-kw>procedure</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#procedure">Procedure</a></td></tr>
+<tr><td><el-kw>procedure</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#procedure">Procedure</a></td></tr>
 <tr><td>Prompt</td><td>IDE</td><td>see <a href="IDEGuide.html#Prompt">Code entry prompts</a></td></tr>
-<tr><td><el-code><el-kw>property</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#property">Property</a></td></tr>
+<tr><td><el-kw>property</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#property">Property</a></td></tr>
 <tr><td>Punctuation symbols</td><td>topic</td><td>see <a href="#PunctuationSymbols">Punctuation symbols</a></td></tr>
-<tr><td><el-code><el-method>push</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#push">push</a> in <a href="LibRef.html#StackFunctions">Stack functions</a></td></tr>
-<tr><td><el-code><el-method>put</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#put_Array">Array</a>, <a href="LibRef.html#put_Array2D">Array2D</a>, <a href="LibRef.html#put_List">List</a> and <a href="LibRef.html#put_Dictionary">Dictionary</a></td></tr>
+<tr><td><el-method>push</el-method></td><td>method</td><td>see <a href="LibRef.html#push">push</a> in <a href="LibRef.html#StackFunctions">Stack functions</a></td></tr>
+<tr><td><el-method>put</el-method></td><td>method</td><td>see <a href="LibRef.html#put_Array">Array</a>, <a href="LibRef.html#put_Array2D">Array2D</a>, <a href="LibRef.html#put_List">List</a> and <a href="LibRef.html#put_Dictionary">Dictionary</a></td></tr>
 <tr id="Q" class="subhead"><td colspan="3">Q &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-type>Queue</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Queue">Queue</a></td></tr>
-<tr><td><el-code><el-id>quotes</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#StringConstants">String constants</a></td></tr>
+<tr><td><el-type>Queue</el-type></td><td>Type</td><td>see <a href="LibRef.html#Queue">Queue</a></td></tr>
+<tr><td><el-id>quotes</el-id></td><td>constant</td><td>see <a href="LibRef.html#StringConstants">String constants</a></td></tr>
 <tr id="R" class="subhead"><td colspan="3">R &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>radToDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#radToDeg">radToDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>random</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#random">random</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-type>Random</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Random">Random</a></td></tr>
-<tr><td><el-code><el-method>randomInt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#randomInt">randomInt</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
-<tr><td><el-code><el-method>range</el-method></el-code></td><td>method</td><td>see <a href="LangRef.html#range">range</a> in <a href="LangRef.html#IndexedValues">Indexed values</a></td></tr>
-<tr><td><el-code><el-method>readLine</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#readLine">readLine</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-method>readWholeFile</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#readWholeFile">readWholeFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-kw>record</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#record">Record</a></td></tr>
-<tr><td><el-code><el-type>RectangleVG</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#RectangleVG">RectangleVG</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-method>radToDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#radToDeg">radToDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>random</el-method></td><td>method</td><td>see <a href="LibRef.html#random">random</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-type>Random</el-type></td><td>Type</td><td>see <a href="LibRef.html#Random">Random</a></td></tr>
+<tr><td><el-method>randomInt</el-method></td><td>method</td><td>see <a href="LibRef.html#randomInt">randomInt</a> in <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
+<tr><td><el-method>range</el-method></td><td>method</td><td>see <a href="LangRef.html#range">range</a> in <a href="LangRef.html#IndexedValues">Indexed values</a></td></tr>
+<tr><td><el-method>readLine</el-method></td><td>method</td><td>see <a href="LibRef.html#readLine">readLine</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-method>readWholeFile</el-method></td><td>method</td><td>see <a href="LibRef.html#readWholeFile">readWholeFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-kw>record</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#record">Record</a></td></tr>
+<tr><td><el-type>RectangleVG</el-type></td><td>Type</td><td>see <a href="LibRef.html#RectangleVG">RectangleVG</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr><td>Recursion</td><td>topic</td><td>see <a href="LangRef.html#recursion">Recursion</a></td></tr>
-<tr><td><el-code><el-id>red</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-method>reduce</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#reduce">reduce</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-kw>ref</el-kw></el-code></td><td>keyword</td><td>see <a href="LibRef.html#ref">ref</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-id>red</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-method>reduce</el-method></td><td>method</td><td>see <a href="LibRef.html#reduce">reduce</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-kw>ref</el-kw></td><td>keyword</td><td>see <a href="LibRef.html#ref">ref</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
 <tr><td>Regular expression</td><td>topic</td><td>see <a href="LibRef.html#RegExp">Regular expressions</a></td></tr>
-<tr><td><el-code><el-method>remove</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#remove">remove</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>removeAll</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#removeAll">removeAll</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>removeAt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#removeAt">removeAt</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>removeFirst</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#removeFirst">removeFirst</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-kw>repeat</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#repeat">Repeat loop</a></td></tr>
-<tr><td><el-code><el-method>replace</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#replace">replace</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-kw>return</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#function">return</a></td></tr>
-<tr><td><el-code><el-kw>returns</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#function">returns</a></td></tr>
-<tr><td><el-code><el-method>round</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#round">round</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>remove</el-method></td><td>method</td><td>see <a href="LibRef.html#remove">remove</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>removeAll</el-method></td><td>method</td><td>see <a href="LibRef.html#removeAll">removeAll</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>removeAt</el-method></td><td>method</td><td>see <a href="LibRef.html#removeAt">removeAt</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>removeFirst</el-method></td><td>method</td><td>see <a href="LibRef.html#removeFirst">removeFirst</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-kw>repeat</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#repeat">Repeat loop</a></td></tr>
+<tr><td><el-method>replace</el-method></td><td>method</td><td>see <a href="LibRef.html#replace">replace</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-kw>return</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#function">return</a></td></tr>
+<tr><td><el-kw>returns</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#function">returns</a></td></tr>
+<tr><td><el-method>round</el-method></td><td>method</td><td>see <a href="LibRef.html#round">round</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
 <tr><td>Run controls</td><td>IDE</td><td>see <a href="IDEGuide.html#RunControls">Run controls</a></td></tr>
 <tr id="S" class="subhead"><td colspan="3">S &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>saveAndClose</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#saveAndClose">saveAndClose</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-kw>set</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#set">Set statement</a></td></tr>
-<tr><td><el-code><el-type>Set</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-method>show</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#show">show</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>sin</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#sin">sin</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>sinDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#sinDeg">sinDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>sortBy</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#sortBy">sortBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
-<tr><td><el-code><el-method>split</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#split">split</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>sqrt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#sqrt">sqrt</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-type>Stack</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#Stack">Stack</a></td></tr>
+<tr><td><el-method>saveAndClose</el-method></td><td>method</td><td>see <a href="LibRef.html#saveAndClose">saveAndClose</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-method>sequence</el-method></td><td>method</td><td>see <a href="LibRef.html#sequence">sequence</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
+<tr><td><el-kw>set</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#set">Set statement</a></td></tr>
+<tr><td><el-type>Set</el-type></td><td>Type</td><td>see <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>show</el-method></td><td>method</td><td>see <a href="LibRef.html#show">show</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>sin</el-method></td><td>method</td><td>see <a href="LibRef.html#sin">sin</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>sinDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#sinDeg">sinDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>sortBy</el-method></td><td>method</td><td>see <a href="LibRef.html#sortBy">sortBy</a> in <a href="LibRef.html#HoFs">Higher-order Functions</a></td></tr>
+<tr><td><el-method>split</el-method></td><td>method</td><td>see <a href="LibRef.html#split">split</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>sqrt</el-method></td><td>method</td><td>see <a href="LibRef.html#sqrt">sqrt</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-type>Stack</el-type></td><td>Type</td><td>see <a href="LibRef.html#Stack">Stack</a></td></tr>
 <tr><td>Standalone function</td><td>topic</td><td>see <a href="LibRef.html#StandaloneFunctions">Standalone functions</a></td></tr>
 <tr><td>Standalone procedure</td><td>topic</td><td>see <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
 <tr><td>Standard data structures</td><td>topic</td><td>see <a href="LibRef.html#StandardDataStructures">Standard data structures</a></td></tr>
 <tr><td>Statement instruction</td><td>topic</td><td>see <a href="LangRef.html#StatementInstructions">Statement instructions</a></td></tr>
 <tr><td>Statement prompt</td><td>IDE</td><td>see <a href="IDEGuide.html#StatementPrompt">Statement prompt</a></td></tr>
-<tr><td><el-code><el-kw>step</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#step">step</a> in <a href="LangRef.html#for">For loop</a></td></tr>
-<tr><td><el-code><el-type>String</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-method>strokeColour</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#strokeColour">strokeColour</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
-<tr><td><el-code><el-method>strokeWidth</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#strokeWidth">strokeWidth</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-kw>step</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#step">step</a> in <a href="LangRef.html#for">For loop</a></td></tr>
+<tr><td><el-type>String</el-type></td><td>Type</td><td>see <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>strokeColour</el-method></td><td>method</td><td>see <a href="LibRef.html#strokeColour">strokeColour</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-method>strokeWidth</el-method></td><td>method</td><td>see <a href="LibRef.html#strokeWidth">strokeWidth</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr><td>Subclass</td><td>topic</td><td>see <a href="LangRef.html#Subclass">Subclass</a></td></tr>
 <tr><td>Superclass</td><td>topic</td><td>see <a href="LangRef.html#Superclass">Superclass</a></td></tr>
 <tr><td>Symbol, punctuation</td><td>topic</td><td>see <a href="#PunctuationSymbols">Punctuation symbols</a></td></tr>
 <tr><td>System info</td><td>IDE</td><td>see <a href="IDEGuide.html#SystemInfo">System info</a></td></tr>
 <tr><td>System method</td><td>topic</td><td>see <a href="LibRef.html#SystemMethods">System methods</a></td></tr>
 <tr id="T" class="subhead"><td colspan="3">T &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>tail</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#tail">tail</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>tan</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#tan">tan</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-method>tanDeg</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#tanDeg">tanDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
-<tr><td><el-code><el-kw>test</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#test">Tests</a></td></tr>
-<tr><td><el-code><el-type>TextFileReader</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TextFileReader">TextFileReader</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-type>TextFileWriter</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TextFileWriter">TextFileWriter</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-type>TextVG</el-type></el-code></td><td>Type</td><td>TextVG has not been implemented yet, and will be in a future release</td></tr>
-<tr><td><el-code><el-kw>then</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
-<tr><td><el-code><el-kw>throw</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#throw">Throw statement</a></td></tr>
-<tr><td><el-code><el-kw>to</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
-<tr><td><el-code><el-id>transparent</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-method>trim</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#trim">trim</a> in <a href="LibRef.html#String">String</a></td></tr>
-<tr><td><el-code><el-id>true</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#true">Boolean constants</a></td></tr>
-<tr><td><el-code><el-kw>try</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#try">Try statement</a></td></tr>
-<tr><td><el-code><el-kw>Tuple</el-kw></el-code></td><td>Type</td><td>see <a href="LibRef.html#Tuple">Tuple</a></td></tr>
-<tr><td><el-code><el-method>turn</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#turn">turn</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-method>turnToHeading</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#turnToHeading">turnToHeading</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
-<tr><td><el-code><el-type>Turtle</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>tail</el-method></td><td>method</td><td>see <a href="LibRef.html#tail">tail</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>tan</el-method></td><td>method</td><td>see <a href="LibRef.html#tan">tan</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-method>tanDeg</el-method></td><td>method</td><td>see <a href="LibRef.html#tanDeg">tanDeg</a> in <a href="LibRef.html#MathsFunctions">Maths functions</a></td></tr>
+<tr><td><el-kw>test</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#test">Tests</a></td></tr>
+<tr><td><el-type>TextFileReader</el-type></td><td>Type</td><td>see <a href="LibRef.html#TextFileReader">TextFileReader</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-type>TextFileWriter</el-type></td><td>Type</td><td>see <a href="LibRef.html#TextFileWriter">TextFileWriter</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-type>TextVG</el-type></td><td>Type</td><td>TextVG has not been implemented yet, and will be in a future release</td></tr>
+<tr><td><el-kw>then</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#if_statement">If statement</a></td></tr>
+<tr><td><el-kw>throw</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#throw">Throw statement</a></td></tr>
+<tr><td><el-kw>to</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#for">For loop</a></td></tr>
+<tr><td><el-id>transparent</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-method>trim</el-method></td><td>method</td><td>see <a href="LibRef.html#trim">trim</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-id>true</el-id></td><td>constant</td><td>see <a href="LibRef.html#true">Boolean constants</a></td></tr>
+<tr><td><el-kw>try</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#try">Try statement</a></td></tr>
+<tr><td><el-kw>Tuple</el-kw></td><td>Type</td><td>see <a href="LibRef.html#Tuple">Tuple</a></td></tr>
+<tr><td><el-method>turn</el-method></td><td>method</td><td>see <a href="LibRef.html#turn">turn</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-method>turnToHeading</el-method></td><td>method</td><td>see <a href="LibRef.html#turnToHeading">turnToHeading</a> in <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
+<tr><td><el-type>Turtle</el-type></td><td>Type</td><td>see <a href="LibRef.html#TurtleGraphics">Turtle graphics</a></td></tr>
 <tr><td>Type</td><td>Topic</td><td>see <a href="LibRef.html#ValueTypes">Value Types</a></td></tr>
 <tr id="U" class="subhead"><td colspan="3">U &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>unicode</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#unicode">Unicode</a> and <a href="LibRef.html#CharacterSets">Character sets</a></td></tr>
-<tr><td><el-code><el-method>union</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#union">union</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
-<tr><td><el-code><el-method>upperCase</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#upperCase">upperCase</a> in <a href="LibRef.html#String">String</a></td></tr>
+<tr><td><el-method>unicode</el-method></td><td>method</td><td>see <a href="LibRef.html#unicode">unicode</a> in <a href="LibRef.html#StandaloneFunctions">Standalone functions</a> and <a href="LibRef.html#CharacterSets">Character sets</a></td></tr>
+<tr><td><el-method>union</el-method></td><td>method</td><td>see <a href="LibRef.html#union">union</a> in <a href="LibRef.html#SetType">Set (data structure)</a></td></tr>
+<tr><td><el-method>upperCase</el-method></td><td>method</td><td>see <a href="LibRef.html#upperCase">upperCase</a> in <a href="LibRef.html#String">String</a></td></tr>
 <tr id="V" class="subhead"><td colspan="3">V &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr><td>Value Type</td><td>topic</td><td>see <a href="LibRef.html#ValueTypes">Value Types</a></td></tr>
-<tr><td><el-code><el-method>values</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#values">values</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
-<tr><td><el-code><el-kw>variable</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#variable">Variable statement</a></td></tr>
-<tr><td><el-code><el-type>VectorGraphic</el-type></el-code></td><td>Type</td><td>see <a href="LibRef.html#VectorGraphic">VectorGraphic</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
+<tr><td><el-method>values</el-method></td><td>method</td><td>see <a href="LibRef.html#values">values</a> in <a href="LibRef.html#Dictionary">Dictionary</a></td></tr>
+<tr><td><el-kw>variable</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#variable">Variable statement</a></td></tr>
+<tr><td><el-type>VectorGraphic</el-type></td><td>Type</td><td>see <a href="LibRef.html#VectorGraphic">VectorGraphic</a> in <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr><td>Vector graphics</td><td>topic</td><td>see <a href="LibRef.html#VectorGraphics">Vector graphics</a></td></tr>
 <tr id="W" class="subhead"><td colspan="3">W &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-method>waitForKey</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#waitForKey">waitForKey</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
-<tr><td><el-code><el-kw>while</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#while">While loop</a></td></tr>
-<tr><td><el-code><el-id>white</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
-<tr><td><el-code><el-kw>with</el-kw></el-code></td><td>keyword</td><td>see <a href="LangRef.html#copyWith">Copy with</a></td></tr>
-<tr><td><el-code><el-method>withInsert</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withInsert">withInsert</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>withPut</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>withRemoveAll</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveAll">withRemoveAll</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>withRemoveAt</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
-<tr><td><el-code><el-method>withRemoveFirst</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#withRemoveFirst">withRemoveFirst</a> in <a href="LibRef.html#List">List</a></td></tr>
-<tr><td><el-code><el-method>writeLine</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#writeLine">writeLine</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
-<tr><td><el-code><el-method>writeWholeFile</el-method></el-code></td><td>method</td><td>see <a href="LibRef.html#writeWholeFile">writeWholeFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-method>waitForKey</el-method></td><td>method</td><td>see <a href="LibRef.html#waitForKey">waitForKey</a> in <a href="LibRef.html#StandaloneProcedures">Standalone procedures</a></td></tr>
+<tr><td><el-kw>while</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#while">While loop</a></td></tr>
+<tr><td><el-id>white</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-kw>with</el-kw></td><td>keyword</td><td>see <a href="LangRef.html#copyWith">Copy with</a></td></tr>
+<tr><td><el-method>withInsert</el-method></td><td>method</td><td>see <a href="LibRef.html#withInsert">withInsert</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>withPut</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>withRemoveAll</el-method></td><td>method</td><td>see <a href="LibRef.html#withRemoveAll">withRemoveAll</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>withRemoveAt</el-method></td><td>method</td><td>see <a href="LibRef.html#CommonDotMethods">Common dot methods</a></td></tr>
+<tr><td><el-method>withRemoveFirst</el-method></td><td>method</td><td>see <a href="LibRef.html#withRemoveFirst">withRemoveFirst</a> in <a href="LibRef.html#List">List</a></td></tr>
+<tr><td><el-method>writeLine</el-method></td><td>method</td><td>see <a href="LibRef.html#writeLine">writeLine</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
+<tr><td><el-method>writeWholeFile</el-method></td><td>method</td><td>see <a href="LibRef.html#writeWholeFile">writeWholeFile</a> in <a href="LibRef.html#Input/output">Input/output</a></td></tr>
 <tr id="X" class="subhead"><td colspan="3">X &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 <tr id="Y" class="subhead"><td colspan="3">Y &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
-<tr><td><el-code><el-id>yellow</el-id></el-code></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
+<tr><td><el-id>yellow</el-id></td><td>constant</td><td>see <a href="LibRef.html#Colours">Colours</a></td></tr>
 <tr id="Z" class="subhead"><td colspan="3">Z &nbsp; &nbsp;<a href="#top">return to top</a></td></tr>
 </table>
 
@@ -394,16 +395,16 @@
 <table>
  <tr><th colspan="3">Punctuation symbols</th></tr>
  <tr><td>(&nbsp;&nbsp;)</td><td>brackets</td><td>used in arithmetic or logical expressions to define order of evaluation,<br> and to enclose a list of arguments or parameters</td></tr>
- <tr><td>[&nbsp;&nbsp;]</td><td>square brackets</td><td>used to enclose a literal list in a <b>mutable</b> structure: <a href="LibRef.html#Array"><el-code><el-type>Array</el-type></el-code></a>, <a href="LibRef.html#List"><el-code><el-type>List</el-type></el-code></a>
- or <a href="LibRef.html#Dictionary"><el-code><el-type>Dictionary</el-type></el-code></a>,<br>or to define an index, or an index-range</td></tr>
- <tr><td>{&nbsp;&nbsp;}</td><td>braces</td><td>(curly brackets) used to enclose a literal list in an <b>immutable</b> structure: <a href="LibRef.html#ListImmutable"><el-code><el-type>ListImmutable</el-type></el-code></a> or <a href="LibRef.html#DictionaryImmutable"><el-code><el-type>DictionaryImmutable</el-type></el-code></a>,<br>or to define an 'interpolated field'
-  within a literal <a href="LibRef.html#String"><el-code><el-type>String</el-type></el-code></a><br>
- See also the constants <a href="LibRef.html#openBrace"><el-code><el-id>openBrace</el-id></el-code></a> and <a href="LibRef.html#closeBrace"><el-code><el-id>closeBrace</el-id></el-code></a></td>
- </tr><tr><td>.</td><td>dot</td><td>(full stop, period) used in defining a fractional (non-integer) number (a <a href="LibRef.html#Float"><el-code><el-type>Float</el-type></el-code></a>),<br>or to access a method or property using 'dot syntax'</td></tr>
+ <tr><td>[&nbsp;&nbsp;]</td><td>square brackets</td><td>used to enclose a literal list in a <b>mutable</b> structure: <a href="LibRef.html#Array"><el-type>Array</el-type></a>, <a href="LibRef.html#List"><el-type>List</el-type></a>
+ or <a href="LibRef.html#Dictionary"><el-type>Dictionary</el-type></a>,<br>or to define an index, or an index-range</td></tr>
+ <tr><td>{&nbsp;&nbsp;}</td><td>braces</td><td>(curly brackets) used to enclose a literal list in an <b>immutable</b> structure: <a href="LibRef.html#ListImmutable"><el-type>ListImmutable</el-type></a> or <a href="LibRef.html#DictionaryImmutable"><el-type>DictionaryImmutable</el-type></a>,<br>or to define an 'interpolated field'
+  within a literal <a href="LibRef.html#String"><el-type>String</el-type></a><br>
+ See also the constants <a href="LibRef.html#openBrace"><el-id>openBrace</el-id></a> and <a href="LibRef.html#closeBrace"><el-id>closeBrace</el-id></a></td>
+ </tr><tr><td>.</td><td>dot</td><td>(full stop, period) used in defining a fractional (non-integer) number (a <a href="LibRef.html#Float"><el-type>Float</el-type></a>),<br>or to access a method or property using 'dot syntax'</td></tr>
  <tr><td>..</td><td>double-dot</td><td>used to define an index-range</td></tr>
  <tr><td>,</td><td>comma</td><td>used to separate items in several  forms of list</td></tr>
- <tr><td>:</td><td>colon</td><td>used to define a key:value pair in a literal <a href="LibRef.html#Dictionary"><el-code><el-type>Dictionary</el-type></el-code></a>
- or <a href="LibRef.html#DictionaryImmutable"><el-code><el-type>DictionaryImmutable</el-type></el-code></a></td></tr>
+ <tr><td>:</td><td>colon</td><td>used to define a key:value pair in a literal <a href="LibRef.html#Dictionary"><el-type>Dictionary</el-type></a>
+ or <a href="LibRef.html#DictionaryImmutable"><el-type>DictionaryImmutable</el-type></a></td></tr>
  <tr><td>+</td><td>plus</td><td>the addition operator</td></tr>
  <tr><td>-</td><td>minus</td><td>the subtraction operator,<br>or the unary negation operator</td></tr>
  <tr><td>*</td><td>multiply</td><td>the multiplication operator</td></tr>
@@ -413,11 +414,11 @@
  <tr><td>&gt;</td><td>greater than</td><td>comparison operator</td></tr>
  <tr><td>&lt;=</td><td>less than or equal to</td><td>comparison operator</td></tr>
  <tr><td>&gt;=</td><td>greater than or equal to</td><td>comparison operator</td></tr>
- <tr><td>=&gt;</td><td>fat arrow</td><td>used in a <a href="LangRef.html#lambda"><el-code><el-kw>lambda</el-kw></el-code></a> to signify 'returns'</td></tr>
+ <tr><td>=&gt;</td><td>fat arrow</td><td>used in a <a href="LangRef.html#lambda"><el-kw>lambda</el-kw></a> to signify 'returns'</td></tr>
  <tr><td>_</td><td>underscore</td><td>the only punctuation symbol that may be used within an <a href="LangRef.html#Identifier">identifier</a> (name),<br>
-also used to 'discard' elements when deconstructing a <a href="LibRef.html#Tuple"><el-code><el-type>Tuple</el-type></el-code></a>
- or a <a href="LibRef.html#ListImmutable"><el-code><el-type>ListImmutable</el-type></el-code></a></td></tr>
- <tr><td>&quot;</td><td>double-quotes</td><td>the delimiter for a literal <a href="LibRef.html#String"><el-code><el-type>String</el-type></el-code></a><br>See also the constant <a href="LibRef.html#quotes"><el-code><el-id>quotes</el-id></el-code></a></td></tr>
+also used to 'discard' elements when deconstructing a <a href="LibRef.html#Tuple"><el-type>Tuple</el-type></a>
+ or a <a href="LibRef.html#ListImmutable"><el-type>ListImmutable</el-type></a></td></tr>
+ <tr><td>&quot;</td><td>double-quotes</td><td>the delimiter for a literal <a href="LibRef.html#String"><el-type>String</el-type></a><br>See also the constant <a href="LibRef.html#quotes"><el-id>quotes</el-id></a></td></tr>
  <tr><td>#</td><td>hash</td><td>prefaces a <a href="LangRef.html#Comment">comment</a></td></tr>
 </table>
 <hr>

--- a/src/documentation/LibRef.html
+++ b/src/documentation/LibRef.html
@@ -2517,7 +2517,6 @@ All the maths functions take a <el-type>Float</el-type> argument and return a <e
   <td>&#x1d452<sup>&#x1d465</sup> where &#x1d465 is the argument and<br>&#x1d452 is Euler's number 2.718281828459045..<br>the base of natural logarithms</td>
   <td></td>
 </tr>
-
 <tr id="logE"><td><el-method>logE</el-method></td><td><el-type>Float</el-type></td><td></td><td>natural logarithm of the input</td><td></td></tr>
 <tr id="log10"><td><el-method>log10</el-method></td><td><el-type>Float</el-type></td><td></td><td>base-10 logarithm of the input</td><td></td></tr>
 <tr id="log2"><td><el-method>log2</el-method></td><td><el-type>Float</el-type></td><td></td><td>base-2 logarithm of the input</td><td></td></tr>

--- a/src/documentation/accordion.js
+++ b/src/documentation/accordion.js
@@ -1,0 +1,13 @@
+var acc = document.getElementsByClassName("accordion");
+var i;
+for (i = 0; i < acc.length; i++) {
+  acc[i].addEventListener("click", function() {
+    this.classList.toggle("active");
+    var panel = this.nextElementSibling;
+    if (panel.style.maxHeight) {
+      panel.style.maxHeight = null;
+    } else {
+      panel.style.maxHeight = panel.scrollHeight + "px";
+    }
+  });
+}

--- a/src/styles/documentation.css
+++ b/src/styles/documentation.css
@@ -76,7 +76,7 @@ table
   float: left;
   padding-right: 20px;
 }
-/* to hide button 'Skip table of contents' */
+/* to hide the 'Skip table of contents' button */
 .hidden { visibility: hidden; }
 
 /* Paragraph style  'ListImmutable Paragraph 2'  What was this for? Currently commented out */
@@ -93,6 +93,12 @@ el-code-block img {
   margin: 0;
 }
 
+/* special tables */
+.tableAccordion {
+ tr:nth-child(even) td { background-color: rgb(255, 255, 255); }
+ tr:nth-child(odd)  td { background-color: rgb(226, 226, 226); }
+}
+
 /* Links in index */
 a:link {text-decoration: none}
 a:visited {text-decoration: none}
@@ -102,4 +108,33 @@ a:active {text-decoration: none}
 /* This avoids the need to have <el-code> around small snippets*/
  el-kw, el-type, el-id, el-method, el-lit {
   font-family: consolas, monospace;
+}
+
+/* Animated accordion and panel  */
+.accordion {
+  text-align: left;
+  padding: 10px 0px;
+  width: 100%;
+}
+
+.accordion::before {
+  content: '\002B';
+  color: blue;
+  font-weight: bold;
+  float: left;
+}
+
+.active, .accordion:hover {
+  cursor: pointer;
+}
+
+.active::before {
+  content: "\2212";
+}
+
+.panel {
+  max-height: 0;
+  width: 100%;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out;
 }


### PR DESCRIPTION
Preliminary addition to documentation.css for EditorRef styling.
Standalone method `sequence` added to ElanIndex (already described in LibRef).
Redundant `<el-code>` tags removed from ElanIndex.