### PR TITLE
Range and double index type checking #1942

### DIFF
--- a/src/compiler/syntax-nodes/ast-helpers.ts
+++ b/src/compiler/syntax-nodes/ast-helpers.ts
@@ -438,14 +438,15 @@ export function compileSimpleSubscript(
   compileErrors: CompileError[],
   fieldId: string,
 ) {
+  const [indexType] = getIndexAndOfType(rootType);
   if (index.index instanceof IndexDoubleAsn) {
     mustBeDoubleIndexableType(id, rootType, true, compileErrors, fieldId);
+    mustBeAssignableType(indexType, index.index.index1.symbolType(), compileErrors, fieldId);
+    mustBeAssignableType(indexType, index.index.index2.symbolType(), compileErrors, fieldId);
   } else {
     mustBeIndexableType(id, rootType, true, compileErrors, fieldId);
+    mustBeAssignableType(indexType, index.index.symbolType(), compileErrors, fieldId);
   }
-  const [indexType] = getIndexAndOfType(rootType);
-  mustBeAssignableType(indexType, index.index.symbolType(), compileErrors, fieldId);
-
   return wrapSimpleSubscript(`${prefix}${code}, ${postfix}`);
 }
 

--- a/src/compiler/syntax-nodes/index-asn.ts
+++ b/src/compiler/syntax-nodes/index-asn.ts
@@ -2,7 +2,6 @@ import { AstNode } from "../../compiler/compiler-interfaces/ast-node";
 import { ChainedAsn } from "../../compiler/compiler-interfaces/chained-asn";
 import { Scope } from "../../compiler/compiler-interfaces/scope";
 import { SymbolType } from "../../compiler/compiler-interfaces/symbol-type";
-import { IntType } from "../../compiler/symbols/int-type";
 import { getGlobalScope } from "../../compiler/symbols/symbol-helpers";
 import { UnknownType } from "../../compiler/symbols/unknown-type";
 import {
@@ -72,7 +71,18 @@ export class IndexAsn extends AbstractAstNode implements AstNode, ChainedAsn {
   compileRange(indexedType: SymbolType, indexed: string, subscript: string) {
     mustBeRangeableType(indexedType, true, this.compileErrors, this.fieldId);
     const [indexType] = getIndexAndOfType(indexedType);
-    mustBeAssignableType(indexType, IntType.Instance, this.compileErrors, this.fieldId);
+    mustBeAssignableType(
+      indexType,
+      (this.index as RangeAsn).from.symbolType(),
+      this.compileErrors,
+      this.fieldId,
+    );
+    mustBeAssignableType(
+      indexType,
+      (this.index as RangeAsn).to.symbolType(),
+      this.compileErrors,
+      this.fieldId,
+    );
     return this.wrapRange(`${indexed}, ${subscript}`);
   }
 

--- a/src/compiler/syntax-nodes/index-double-asn.ts
+++ b/src/compiler/syntax-nodes/index-double-asn.ts
@@ -9,8 +9,8 @@ import { UnaryExprAsn } from "./unary-expr-asn";
 
 export class IndexDoubleAsn extends AbstractAstNode implements AstNode {
   constructor(
-    private readonly index1: AstNode,
-    private readonly index2: AstNode,
+    public readonly index1: AstNode,
+    public readonly index2: AstNode,
     public readonly fieldId: string,
     private readonly scope: Scope,
   ) {

--- a/src/compiler/syntax-nodes/range-asn.ts
+++ b/src/compiler/syntax-nodes/range-asn.ts
@@ -10,8 +10,8 @@ import { UnaryExprAsn } from "./unary-expr-asn";
 
 export class RangeAsn extends AbstractAstNode implements AstNode {
   constructor(
-    private readonly from: AstNode,
-    private readonly to: AstNode,
+    public readonly from: AstNode,
+    public readonly to: AstNode,
     public readonly fieldId: string,
     private readonly scope: Scope,
   ) {

--- a/test/compiler/array2d.test.ts
+++ b/test/compiler/array2d.test.ts
@@ -770,4 +770,31 @@ end record`;
       "Array2D must be of Type: Int, Float, String, or Boolean, with matching initial value",
     );
   });
+
+  test("Fail_IndexNotInt", async () => {
+    const code = `${testHeader}
+
+main
+  variable a set to new Array2D<of String>(3, 2, "")
+  variable b set to a["0", 1]
+  variable c set to a[0, 0.5]
+end main
+`;
+
+    const fileImpl = new FileImpl(
+      testHash,
+      new DefaultProfile(),
+      "",
+      transforms(),
+      new StdLib(new StubInputOutput()),
+      true,
+    );
+    await fileImpl.parseFrom(new CodeSourceFromString(code));
+
+    assertParses(fileImpl);
+    assertDoesNotCompile(fileImpl, [
+      "Incompatible types. Expected: Int, Provided: String.LangRef.html#TypesCompileError",
+      "Incompatible types. Expected: Int, Provided: Float.LangRef.html#TypesCompileError",
+    ]);
+  });
 });

--- a/test/compiler/list.test.ts
+++ b/test/compiler/list.test.ts
@@ -2206,4 +2206,30 @@ end main
     assertStatusIsValid(fileImpl);
     await assertObjectCodeDoesNotExecute(fileImpl, "Out of range index: 5 size: 5");
   });
+
+  test("Fail_RangeNotInt", async () => {
+    const code = `${testHeader}
+
+main
+    variable a set to [1,2,3,4]
+    variable b set to a["2"..5]
+    variable c set to a[2..5.0]
+end main`;
+
+    const fileImpl = new FileImpl(
+      testHash,
+      new DefaultProfile(),
+      "",
+      transforms(),
+      new StdLib(new StubInputOutput()),
+      true,
+    );
+    await fileImpl.parseFrom(new CodeSourceFromString(code));
+
+    assertParses(fileImpl);
+    assertDoesNotCompile(fileImpl, [
+      "Incompatible types. Expected: Int, Provided: String.LangRef.html#TypesCompileError",
+      "Incompatible types. Expected: Int, Provided: Float.LangRef.html#TypesCompileError",
+    ]);
+  });
 });


### PR DESCRIPTION
Indices in range (eg a[3..6]) and double (Array2D eg a[2, 3]) were not being type-checked properly, eg a["2".."6"] was being accepted.
I had to change a few class properties from private to public; I hope that is OK. Two tests added.
The change that I suggested in part three of the Issue caused a lot of test failures so I have backed it out (src/compiler/compile-rules.ts).