### PR TITLE
Clicking on property symbol completions, and Backspace #2013 abstract-field.ts

### DIFF
--- a/src/ide/frames/fields/abstract-field.ts
+++ b/src/ide/frames/fields/abstract-field.ts
@@ -144,7 +144,9 @@ export abstract class AbstractField implements Selectable, Field {
 
   processAutocompleteText(txt: string | undefined) {
     if (txt) {
-      this.selectedSymbolCompletion = this.allPossibleSymbolCompletions.find((s) => s.name === txt);
+      this.selectedSymbolCompletion = this.allPossibleSymbolCompletions.find(
+        (s) => s.displayName === txt,
+      );
     }
   }
 
@@ -508,6 +510,7 @@ export abstract class AbstractField implements Selectable, Field {
     this.parseCurrentText();
     this.setSelection(this.text.length);
     this.codeHasChanged = true;
+    this.holder.hasBeenAddedTo();
   }
 
   private tab(back: boolean) {


### PR DESCRIPTION
(a) processAutocompleteText: use "displayName" not "name" to find the item clicked on in a symbol completion drop-down, to match properties.

(b) replaceAutocompletedText: add call to `this.holder.hasBeenAddedTo()` at end to stop Backspace deleting whole line.