### PR TITLE
Add "main()" to the end of the program in Python #2813

### DIFF
--- a/src/ide/frames/file-impl.ts
+++ b/src/ide/frames/file-impl.ts
@@ -18,6 +18,7 @@ import {
   helper_testStatusAsDisplayStatus,
   isMain,
   isSelector,
+  removeHtmlTagsAndEscChars,
 } from "./frame-helpers";
 import { CodeSource } from "./frame-interfaces/code-source";
 import { editorEvent } from "./frame-interfaces/editor-event";
@@ -226,10 +227,11 @@ export class FileImpl implements File {
   public async renderAsHtml(withHeader: boolean = true): Promise<string> {
     this._frNo = 1;
     const globals = parentHelper_renderChildrenAsHtml(this);
+    const trailer = this.language().renderFileTrailerAsHtml();
     this.currentHash = await this.getHash();
     return withHeader
-      ? `<el-header>${this._language.COMMENT_MARKER} ${this.getHashAsHtml()} ${this.getVersionAsHtml()} ${this.getUserNameAsHtml()} ${this.getProfileNameAsHtml()}</el-header>\r\n${globals}`
-      : globals;
+      ? `<el-header>${this._language.COMMENT_MARKER} ${this.getHashAsHtml()} ${this.getVersionAsHtml()} ${this.getUserNameAsHtml()} ${this.getProfileNameAsHtml()}</el-header>\r\n${globals}${trailer}`
+      : `${globals}${trailer}`;
   }
 
   async renderAsSource(): Promise<string> {
@@ -248,8 +250,9 @@ export class FileImpl implements File {
 
   async renderAsExport(): Promise<string> {
     const globals = parentHelper_renderChildrenAsExport(this);
+    const trailer = removeHtmlTagsAndEscChars(this.language().renderFileTrailerAsHtml());
     const lang = this.language().languageFullName;
-    return `${this.language().COMMENT_MARKER} ${this.getVersionString(lang)}\n\n${globals}
+    return `${this.language().COMMENT_MARKER} ${this.getVersionString(lang)}\n\n${globals}${trailer}
 `;
   }
 

--- a/src/ide/frames/frame-interfaces/language.ts
+++ b/src/ide/frames/frame-interfaces/language.ts
@@ -22,6 +22,8 @@ export interface Language {
 
   renderBottomAsHtml(frame: Frame): string;
 
+  renderFileTrailerAsHtml(): string;
+
   getFields(node: Frame): Field[];
 
   addNodesForNewInstance(node: NewInstance): void;

--- a/src/ide/frames/language-abstract.ts
+++ b/src/ide/frames/language-abstract.ts
@@ -61,6 +61,8 @@ export abstract class LanguageAbstract implements Language {
 
   abstract renderBottomAsHtml(frame: Frame): string;
 
+  abstract renderFileTrailerAsHtml(): string;
+
   abstract paramDefAsHtml(node: ParamDefNode): string;
   abstract typeGenericAsHtml(node: TypeGenericNode): string;
   abstract newInstanceAsHtml(node: NewInstance): string;

--- a/src/ide/frames/language-cs.ts
+++ b/src/ide/frames/language-cs.ts
@@ -85,6 +85,10 @@ export class LanguageCS extends LanguageCfamily {
     return this.common_renderBottomAsHtml(frame);
   }
 
+  renderFileTrailerAsHtml(): string {
+    return "";
+  }
+
   addNodesForParamDef(node: ParamDefNode): void {
     this.c_langs_addNodesForParamDef(node);
   }

--- a/src/ide/frames/language-elan.ts
+++ b/src/ide/frames/language-elan.ts
@@ -168,6 +168,10 @@ export class LanguageElan extends LanguageAbstract {
     return `<el-kw>${this.END} ${frame.initialKeywords()}</el-kw>`;
   }
 
+  renderFileTrailerAsHtml(): string {
+    return "";
+  }
+
   private ABSTRACT = "abstract";
   private AS = "as";
   private ASSERT = "assert";

--- a/src/ide/frames/language-java.ts
+++ b/src/ide/frames/language-java.ts
@@ -90,6 +90,10 @@ export class LanguageJava extends LanguageCfamily {
     return this.common_renderBottomAsHtml(frame);
   }
 
+  renderFileTrailerAsHtml(): string {
+    return "";
+  }
+
   public FINAL = "final";
   OVERRIDES = "";
   EXTENDS = "extends";

--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -196,6 +196,10 @@ export class LanguagePython extends LanguageAbstract {
     return ""; // Python blocks have no textual ending;
   }
 
+  renderFileTrailerAsHtml(): string {
+    return "\n\n<el-header>main()</el-header>";
+  }
+
   private DEF = "def";
   private CLASS = "class";
   private ELIF = "elif";

--- a/src/ide/frames/language-vb.ts
+++ b/src/ide/frames/language-vb.ts
@@ -205,6 +205,10 @@ export class LanguageVB extends LanguageAbstract {
     return html;
   }
 
+  renderFileTrailerAsHtml(): string {
+    return "";
+  }
+
   private AS = "As";
   private CATCH = "Catch";
   private CLASS = "Class";

--- a/test/compiler/for-loop.test.ts
+++ b/test/compiler/for-loop.test.ts
@@ -69,6 +69,8 @@ def main() -> None:
   for i in range(1, 11):
     tot = tot + i # set
   printNoLine(tot) # call procedure
+
+main()
 `;
 
     const csCode = `${testCSHeader}

--- a/test/compiler/function.test.ts
+++ b/test/compiler/function.test.ts
@@ -69,6 +69,8 @@ def main() -> None:
 
 def foo(a: float, b: float) -> float: # function
   return a*b
+
+main()
 `;
 
     const csCode = `${testCSHeader}

--- a/test/compiler/main.test.ts
+++ b/test/compiler/main.test.ts
@@ -56,6 +56,8 @@ return [main, _tests];}`;
 
 def main() -> None:
 
+
+main()
 `;
 
     const csCode = `${testCSHeader}

--- a/test/compiler/procedure-statement.test.ts
+++ b/test/compiler/procedure-statement.test.ts
@@ -77,6 +77,8 @@ def main() -> None:
 
 def foo() -> None: # procedure
   printNoLine(2) # call procedure
+
+main()
 `;
 
     const csCode = `${testCSHeader}

--- a/test/compiler/this-and-property.test.ts
+++ b/test/compiler/this-and-property.test.ts
@@ -507,6 +507,8 @@ class Foo
   def toString(self: Foo) -> str: # function
     return ""
 
+
+main()
 `;
     const vbCode = `${testVBHeader}
 
@@ -667,6 +669,7 @@ class Foo
   def toString(self: Foo) -> str: # function
     return ""
 
+main()
 `;
     const vbCode = `${testVBHeader}
 

--- a/test/compiler/variables.test.ts
+++ b/test/compiler/variables.test.ts
@@ -59,6 +59,8 @@ return [main, _tests];}`;
 def main() -> None:
   a = 3 # variable definition
   printNoLine(a) # call procedure
+
+main()
 `;
 
     const csCode = `${testCSHeader}


### PR DESCRIPTION
Add `main()` to the end of the program in Python #2813

The `main()` is visible in the IDE in Python mode, and included in exported files. I updated the tests which used to pass before I made the change but failed after I made the change (by running diff on the filtered test output), so the number of failures remains the same.

I'm a bit new to TypeScript -- I didn't realise that so many files had to change when adding a function to the language classes.  I hope I have done it right -- I just fixed all the compiler errors.

Now a simple program with few library function calls, say `call print(2 + 3)`, runs in Python when exported.  

I don't understand why the diff shows only one line added in `test/compiler/this-and-property.test.ts` for the second addition of `main()`, but the test seems to pass.
