### PR TITLE
Python, change the HTML markup on "main()" line added at the end #2813

### DIFF
--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -200,7 +200,7 @@ export class LanguagePython extends LanguageAbstract {
   }
 
   renderFileTrailerAsHtml(): string {
-    return "\n\n<el-header>main()</el-header>";
+    return "\n\n<el-method>main</el-method>()";
   }
 
   private DEF = "def";


### PR DESCRIPTION
Was `"\n\n<el-header>main()</el-header>"` changed to `"\n\n<el-method>main</el-method>()"` so the colouring looks like a procedure call.
