### PR TITLE
Fix up Python math calls in procedure arguments #2813

### DIFF
--- a/src/ide/frames/fields/arg-list-field.ts
+++ b/src/ide/frames/fields/arg-list-field.ts
@@ -77,7 +77,11 @@ export class ArgListField extends AbstractField {
       this.setPlaceholder(`<i>${allTypes}</i>`);
     }
 
-    return super.textAsHtml();
+    let result = super.textAsHtml();
+    if (this.getFile().doingExport) {
+      result = this.getFile().language().translateExpression(result);
+    }
+    return result;
   }
 
   override getCompletion() {

--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -212,7 +212,7 @@ export class LanguagePython extends LanguageAbstract {
 
   translateExpression(expr: string): string {
     const regexp = new RegExp(
-      `<el-method>(${languageHelper_mathFunctions.join("|")})</el-method>`,
+      `(<el-method>)(${languageHelper_mathFunctions.join("|")})(</el-method>)`,
       "g",
     );
     const result = expr.replace(regexp, this.lookupmath);
@@ -227,12 +227,19 @@ export class LanguagePython extends LanguageAbstract {
   };
   // 'this' is undefined inside a traditional function definition
   // so we use an arrow function so it has access to 'this'
-  private lookupmath = (_match: string, p1: string, _offset: number, _string: string) => {
-    const result = this.mathExceptions[p1] ?? `math.${p1}`;
+  private lookupmath = (
+    _match: string,
+    p1: string,
+    p2: string,
+    p3: string,
+    _offset: number,
+    _string: string,
+  ) => {
+    const result = this.mathExceptions[p2] ?? `math.${p2}`;
     if (result.startsWith("math.")) {
       this.importMath = true;
     }
-    return result;
+    return `${p1}${result}${p3}`;
   };
 
   private DEF = "def";


### PR DESCRIPTION
The previous commit only fixes up math library function calls in expressions, but not procedure call arguments which are handled separately.  I have added the equivalent code to src/ide/frames/fields/arg-list-field.ts so now it works with procedure call arguments like print statements.

Also fixed a bug which made no difference in practice, but was unintentional.  When fixing up eg `<el-method>acos</el-method>` it deleted the `el-method` tags.  All the HTML is stripped anyway before the file is saved, but it could cause confusion in the future, as all of the rest of the HTML is left in place by `translateExpression`.