### PR TITLE
Dot methods that become standalone in Python #2813

### DIFF
--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -211,11 +211,23 @@ export class LanguagePython extends LanguageAbstract {
   }
 
   translateExpression(expr: string): string {
+    // add "math." to math library functions
     const regexp = new RegExp(
       `(<el-method>)(${languageHelper_mathFunctions.join("|")})(</el-method>)`,
       "g",
     );
-    const result = expr.replace(regexp, this.lookupmath);
+    // this is effectively a replaceAll because the regexp has the "g" flag
+    let result = expr.replace(regexp, this.lookupmath);
+
+    // non-math functions which are dot methods and stay dot methods
+    result = this.translateDotMethods(result);
+
+    // extension methods (dot methods) which become standalone functions in Python
+    // and the object becomes the argument
+    // eg li.length() becomes len(li)
+    // or the object becomes the first argument
+    // eg num.round(3) becomes round(num, 3)
+    result = this.translateExtension(result);
     return result;
   }
 
@@ -226,6 +238,7 @@ export class LanguagePython extends LanguageAbstract {
     logE: "math.log",
   };
   // 'this' is undefined inside a traditional function definition
+  // when used as a callback from string "replace()"
   // so we use an arrow function so it has access to 'this'
   private lookupmath = (
     _match: string,
@@ -241,6 +254,166 @@ export class LanguagePython extends LanguageAbstract {
     }
     return `${p1}${result}${p3}`;
   };
+
+  private dotMethodTable: { [propName: string]: string } = {
+    upperCase: "upper",
+    lowerCase: "lower",
+    trim: "strip",
+  };
+  // omitting split: "split" as the name is the same
+
+  // non-math functions which are dot methods and stay dot methods
+  // these just need the name changing, and no import statement is needed
+  // could use regexp lookahead and lookbehind to handle the tags
+  // but I am doing it the way I know for now
+  private translateDotMethods(expr: string): string {
+    return expr.replace(
+      /(${this.METHOPTAG})(${Object.keys(this.dotMethodTable).join("|")})(${this.METHCLTAG})/g,
+      (_match, p1, p2, p3) => `${p1}${this.dotMethodTable[p2]}${p3}`,
+    );
+  }
+
+  private METHOPTAG = "<el-method>"; // open tag
+  private METHCLTAG = "</el-method>"; // close tag
+
+  // we need to distinguish opening and closing quotes
+  // we do this by substituting different characters for them
+  // while we work out the positions of the strings to be moved around
+  // these two characters look a bit like brackets and are unlikely to be entered by users
+  // they go into a local variable in translateExtension() and shouldn't leak out!
+  private OPENQUOTE = "\u2770"; // HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT (U+2770)
+  private CLOSEQUOTE = "\u2771"; // HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT (U+2771)
+  private extensionTable: { [propName: string]: string } = {
+    toString: "str",
+    asUnicode: "ord",
+    length: "len",
+    floor: "math.floor",
+    ceiling: "math.ceil",
+    isNaN: "math.isnan",
+    isInfinite: "math.isinf",
+    round: "round",
+  };
+
+  // Dot methods which translate to standalone functions
+  private translateExtension(expr: string): string {
+    let result = expr;
+    const regexp = new RegExp(
+      `(${this.METHOPTAG})(${Object.keys(this.extensionTable).join("|")})(${this.METHCLTAG})`,
+      "g",
+    );
+    let match;
+    // We scan through the original line "expr" looking for function names to convert
+    // in one pass so that we don't scan the same area twice, in case the name is the same.
+    // note assignment to "match" not a comparison
+    while ((match = regexp.exec(expr))) {
+      // Adjust the match position to take account of the fact that the part
+      // before the match may have already changed in length, but the part
+      // after the match has not changed.
+      // pos2 is the position of the function name in "result".
+      const pos2 = match.index + result.length - expr.length;
+      const funcName = match[2]; // second set of brackets is the function name
+      // convert the quotes so we can distinguish the two ends of a string
+      // we take advantage of the fact that a literal string is marked up
+      // like this: "<el-lit>my string</el-lit>"
+      // just in case a user enters one of these quotes, we remove them first
+      // the replacements are the same length (2) as the originals
+      // this value is thrown away once we have found the correct positions
+      // We also squelch "</" because a division operator is one of the delimiters
+      // which marks the end of the object expression
+      const working = result
+        .replaceAll(this.OPENQUOTE, "z")
+        .replaceAll(this.CLOSEQUOTE, "z")
+        .replaceAll('"<', this.OPENQUOTE + "<")
+        .replaceAll('>"', ">" + this.CLOSEQUOTE)
+        .replaceAll("</", "<@");
+
+      // look back for the beginning of the object expression eg obj.length()
+      let cont = true;
+      let pos1 = pos2;
+      while (cont) {
+        const c = working[pos1];
+        // look for a delimiter
+        if (" ([{,*/".includes(c)) {
+          // found start of object
+          cont = false;
+        } else {
+          if ((")]" + this.CLOSEQUOTE).includes(c)) {
+            // skip to the other end of this string or bracketed expression
+            // "-1" tells findmatch to work backwards towards the start of the string
+            pos1 = this.findmatch(working, pos1, -1);
+          }
+          pos1--;
+        }
+        // TBD need to make findmatch return -1 on running off start of string and catch it
+        // throw new Error(`Can't find start of object ending at ${pos2} in /${expr}/`);
+        if (pos1 < 0) {
+          // reached start of string, that is the start of the object
+          cont = false;
+        }
+      } // while cont
+      // pos1 will be -1 if it scanned right back to the start of the string
+      // that is OK as we always add 1 to it below
+      // move the object to be the argument in the original string
+      // the argument may have already been rewritten earlier.
+      // the trailing "(" on argsPos is deliberate -- that also has to be removed
+      // and is added back before the arguments
+      // If there is already an argument add comma and space
+      // eg num.round(3) --> round(num, 3)
+      // if no args, argsPos points to the closing ")"
+      // if args, argsPos points to first char of args
+      const argsPos = pos2 + `${this.METHOPTAG}${funcName}${this.METHCLTAG}(`.length;
+      const replacement = this.extensionTable[funcName];
+      // "pos2 - 1" with -1 because we want to throw away the dot
+      result =
+        result.substring(0, pos1 + 1) + // up to the delimiter
+        `${this.METHOPTAG}${replacement}${this.METHCLTAG}(` + // new function name
+        result.substring(pos1 + 1, pos2 - 1) + // argument
+        (result[argsPos] === ")" ? "" : ", ") + // if there is already an argument add comma
+        result.substring(argsPos); // rest of the string
+      if (replacement.startsWith("math.")) {
+        this.importMath = true;
+      }
+    } // while regexp.exec
+    return result;
+  }
+
+  // lookup table for the finding of matching brackets and quotes
+  // it accepts some things which are not legal in Elan
+  // dir = 1 = forwards (left to right), dir = -1 = backwards (right to left)
+  private matchtable: { [propName: string]: { close: string; nest: string; dir: number } } = {
+    "(": { close: ")", nest: this.OPENQUOTE + "([", dir: 1 },
+    ")": { close: "(", nest: this.CLOSEQUOTE + ")]", dir: -1 },
+    [this.OPENQUOTE]: { close: this.CLOSEQUOTE, nest: this.OPENQUOTE, dir: 1 },
+    [this.CLOSEQUOTE]: { close: this.OPENQUOTE, nest: this.CLOSEQUOTE, dir: -1 },
+    "[": { close: "]", nest: this.OPENQUOTE + "([", dir: 1 },
+    "]": { close: "[", nest: this.CLOSEQUOTE + ")]", dir: -1 },
+  };
+  // dir = 1 for forwards, -1 for backwards
+  private findmatch(text: string, start: number, dir: number): number {
+    const lup = this.matchtable[text[start]];
+    if (!lup) {
+      throw new Error("Bad opening character /" + text[start] + "/");
+    }
+    // in early versions, some delimiters worked in both directions
+    if (lup.dir !== 0 && lup.dir !== dir) {
+      throw new Error("Opening character /" + text[start] + "/ doesn't match dir " + dir);
+    }
+    let index = start + dir;
+    while (index >= 0 && index < text.length) {
+      const c = text[index];
+      if (c === lup.close) {
+        return index;
+      }
+      if (lup.nest.includes(c)) {
+        index = this.findmatch(text, index, dir);
+        // and continue after the nested element
+      }
+      // else an ordinary character, take no action
+      index += dir;
+    }
+    // ran off end of string
+    throw new Error("No match");
+  }
 
   private DEF = "def";
   private CLASS = "class";

--- a/test/files/binary-search.py
+++ b/test/files/binary-search.py
@@ -16,15 +16,15 @@ def main() -> None:
 
 def binarySearch(li: list[str], item: str) -> bool: # function
   result = False # variable definition
-  if li.length() > 0:
-    mid = divAsInt(li.length(), 2) # constant
+  if len(li) > 0:
+    mid = divAsInt(len(li), 2) # constant
     value = li[mid] # variable definition
     if item.equals(value):
       result = True # change variable
     elif item.isBefore(value):
       result = binarySearch(li.subList(0, mid), item) # change variable
     else:
-      result = binarySearch(li.subList(mid + 1, li.length()), item) # change variable
+      result = binarySearch(li.subList(mid + 1, len(li)), item) # change variable
   return result
 
 def test_binarySearch(self) -> None:

--- a/test/files/collatz.py
+++ b/test/files/collatz.py
@@ -23,7 +23,7 @@ def main() -> None:
       p.append(x) # call procedure
       # draw what we have got so far, scaled to the canvas
       vg = list[VectorGraphic]() # variable definition
-      for i in range(0, p.length() - 1):
+      for i in range(0, len(p) - 1):
         vg = vg.withAppend((LineVG()).withX1(scx(i, p)).withY1(scy(p[i], max)).withX2(scx(i + 1, p)).withY2(scy(p[i + 1], max)).withStrokeWidth(1)) # change variable
       displayVectorGraphics(vg) # call procedure
       print(x)
@@ -33,7 +33,7 @@ def main() -> None:
 # scale x.  We pass in p just to get its length
 
 def scx(i: int, p: list[int]) -> float: # function
-  return divAsFloat(i*100, p.length())
+  return divAsFloat(i*100, len(p))
 
 # scale y
 

--- a/test/files/in-place-ripple-sort.py
+++ b/test/files/in-place-ripple-sort.py
@@ -8,7 +8,7 @@ def main() -> None:
 
 def inPlaceRippleSort(li: list[int]) -> None: # procedure
   hasChanged = True # variable definition
-  lastComp = li.length() - 2 # variable definition
+  lastComp = len(li) - 2 # variable definition
   while hasChanged == True:
     hasChanged = False # change variable
     for i in range(0, lastComp + 1):

--- a/test/files/pathfinder.py
+++ b/test/files/pathfinder.py
@@ -33,7 +33,7 @@ def runSolver(gr: list[list[int]], start: Point, destination: Point, rocks: list
     length = rl.item_1 # constant
     gr2 = addRoute(gr2, route) # change variable
     displayBlocks(gr2) # call procedure
-    printNoLine(f"Length of route: {length.round(2)} ") # call procedure
+    printNoLine(f"Length of route: {round(length, 2)} ") # call procedure
   else:
     printNoLine("No path found. ") # call procedure
 
@@ -69,7 +69,7 @@ def addRoute(gr: list[list[int]], route: list[Point]) -> list[list[int]]: # func
   for p in route:
     graphics = withPut(graphics, p.x, p.y, orange) # change variable
   start = route[0] # variable definition
-  dest = route[route.length() - 1] # variable definition
+  dest = route[len(route) - 1] # variable definition
   graphics = withPut(graphics, start.x, start.y, green) # change variable
   graphics = withPut(graphics, dest.x, dest.y, red) # change variable
   return graphics
@@ -126,7 +126,7 @@ class Solver
     return neighbours
   def getNodeFor(self: Solver, p: Point) -> Node: # function
     matches = self.nodes.filter(lambda n: Node => n.point.equals(p)) # variable definition
-    return if(matches.length() == 1, matches.head(), emptyNode())
+    return if(len(matches) == 1, matches.head(), emptyNode())
   def getLastVisited(self: Solver) -> Point: # function
     return self.current.point
   def nextNodeToVisit(self: Solver) -> Node: # function
@@ -189,7 +189,7 @@ class Node
   def setVia(self: Node, p: Point) -> None: # procedure
     self.via = p # change variable
   def toString(self: Node) -> str: # function
-    return f"[{self.point.toString()} {self.visited} {self.distFromStart}]"
+    return f"[{str(self.point)} {self.visited} {self.distFromStart}]"
 
 
 def emptyPoint() -> Point: # function
@@ -209,7 +209,7 @@ class Point
   def minDistTo(self: Point, p: Point) -> float: # function
     return math.sqrt(pow((p.x - self.x), 2) + pow((p.y - self.y), 2))
   def isAdjacentTo(self: Point, p: Point) -> bool: # function
-    return (self.minDistTo(p) == 1) or (self.minDistTo(p).round(4) == math.sqrt(2).round(4))
+    return (self.minDistTo(p) == 1) or (round(self.minDistTo(p), 4) == round(math.sqrt(2), 4))
   # Returns the 8 theoretically-neighbouring points, whether or not within bounds
   def neighbouringPoints(self: Point) -> list[Point]: # function
     return [Point(self.x - 1, self.y - 1), Point(self.x, self.y - 1), Point(self.x + 1, self.y - 1), Point(self.x - 1, self.y), Point(self.x + 1, self.y), Point(self.x - 1, self.y + 1), Point(self.x, self.y + 1), Point(self.x + 1, self.y + 1)]

--- a/test/files/roman-numerals-turing-machine.py
+++ b/test/files/roman-numerals-turing-machine.py
@@ -14,7 +14,7 @@ def main() -> None:
   tm = TuringMachine(initState, haltState) # variable definition
   addRulesForRomanNumeralsInto(tm) # call procedure
   dec = inputIntBetween("Enter a year:", 1, 3999) # constant
-  tm.setTape(dec.toString()) # call procedure
+  tm.setTape(str(dec)) # call procedure
   steps = 0 # variable definition
   while not tm.isHalted():
     rule = tm.findMatchingRule() # variable definition
@@ -25,7 +25,7 @@ def main() -> None:
     printTab(tm.headPosition - 1, "^") # call procedure
     print(f"Step: {steps}")
     print(f"State: {tm.currentState}")
-    print(f"Rule applied: {rule.toString()}")
+    print(f"Rule applied: {str(rule)}")
     sleep_ms(40) # call procedure
   print(f"The roman numeral equivalent for {dec} is {tm.tape.trim()}")
 
@@ -61,18 +61,18 @@ class TuringMachine
     return self.currentState.equals(self.haltState)
   def findMatchingRule(self: TuringMachine) -> Rule: # function
     matches = self.rules.filter(lambda r: Rule => (r.currentState.equals(self.currentState)) and (r.currentSymbol.equals(self.tape[self.headPosition]))) # variable definition
-    if matches.length() == 0:
+    if len(matches) == 0:
       raise ElanRuntimeError("f"No rule matching state {self.currentState} and symbol {self.tape[self.headPosition]}"")
     return matches.head()
   def write(self: TuringMachine, newSymbol: str) -> None: # procedure
     hp = self.headPosition # constant
-    self.tape = self.tape.subString(0, hp) + newSymbol + self.tape.subString(hp + 1, self.tape.length()) # change variable
+    self.tape = self.tape.subString(0, hp) + newSymbol + self.tape.subString(hp + 1, len(self.tape)) # change variable
   def execute(self: TuringMachine, rule: Rule) -> None: # procedure
     self.currentState = rule.nextState # change variable
     self.write(rule.writeSymbol) # call procedure
     if rule.move == Dir.right:
       self.headPosition = self.headPosition + 1 # change variable
-      if self.headPosition >= self.tape.length():
+      if self.headPosition >= len(self.tape):
         self.tape = self.tape + " " # change variable
     else:
       self.headPosition = self.headPosition - 1 # change variable

--- a/test/files/snake-OOP.py
+++ b/test/files/snake-OOP.py
@@ -38,13 +38,13 @@ class Snake
     if self.head.equals(apple.location):
       apple.newRandomPosition(self) # call procedure
     else:
-      self.body = self.body.subList(1, self.body.length()) # change variable
+      self.body = self.body.subList(1, len(self.body)) # change variable
   def updateBlocks(self: Snake, blocks: list[list[int]]) -> None: # procedure
     blocks[self.head.x][self.head.y] = green # change variable
     if not self.body[0].equals(self.priorTail):
       blocks[self.priorTail.x][self.priorTail.y] = white # change variable
   def score(self: Snake) -> int: # function
-    return self.body.length() - 1
+    return len(self.body) - 1
   def bodyCovers(self: Snake, sq: Square) -> bool: # function
     result = False # variable definition
     for seg in self.body:


### PR DESCRIPTION
Added translation of dot methods that become standalone in Python. viz:
```
    toString: "str",
    asUnicode: "ord",
    length: "len",
    floor: "math.floor",
    ceiling: "math.ceil",
    isNaN: "math.isnan",
    isInfinite: "math.isinf",
    round: "round",
```
and a few that stay as dot methods but get a new name (`upperCase`, `lowerCase`, `trim`).

My carefully crafted code handles nested strings in $-strings, but I now discover that this doesn't currently work in Python. I will find a way to use single quotes but that's for another day.

For the moment I have put all the code into language-python.ts.  If any of it can be generalised for other target languages, we can pull it out later into the helper module.