### PR TITLE
Three export tests skipped by mistake #2889

### DIFF
--- a/test/files/date-time.elan
+++ b/test/files/date-time.elan
@@ -1,4 +1,4 @@
-# 41b0cf400247c7aab3c361dd9f769c32e393bfc20a5dca80b7cef9b7e937cb8c Elan 2.0.0-alpha1 valid
+# 3b2dad6037bd14c2ebc2ffd50b09c8dc29f031bb50f03c0d81bc34b2a06e35d0 Elan 2.0.0-alpha1 valid
 
 main
   variable reply set to ""

--- a/test/files/date-time.py
+++ b/test/files/date-time.py
@@ -1,5 +1,7 @@
 # Python with Elan 2.0.0-alpha1
 
+import math
+
 def main() -> None:
   reply = "" # variable definition
   while not reply.upperCase().equals("Q"):
@@ -45,7 +47,7 @@ def dateTime(unixSecs: int) -> tuple[int, int, int, int, int, int]: # function
   second = (unixSecs % 60) # constant
   # days and years from Unix epoch
   unixDay = divAsInt(unixSecs, daySecs) # constant
-  years = ((unixDay + 1)/365.24).floor() # constant
+  years = math.floor(((unixDay + 1)/365.24)) # constant
   # this year and weekday
   year = unixYear + years # constant
   weekday = (unixDay + unixWeekday) % 7 # constant
@@ -136,7 +138,7 @@ def getStartDays() -> list[int]: # function
   return [1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]
 
 def padLwithZero(i: int) -> str: # function
-  return pad("L", "00", i.toString())
+  return pad("L", "00", str(i))
 
 def test_padLwithZero(self) -> None:
   self.assertEqual(padLwithZero(1), "01")
@@ -148,10 +150,12 @@ def pad(d: str, p: str, s: str) -> str: # function
   # p: output string pattern of pad characters and of length
   # s: input string
   sR = s # variable definition
-  if p.length() > s.length():
+  if len(p) > len(s):
     if d.upperCase().equals("L"):
       ps = p + s # constant
-      sR = ps.subString(ps.length() - p.length(), ps.length()) # change variable
+      sR = ps.subString(len(ps) - len(p), len(ps)) # change variable
     elif d.upperCase().equals("R"):
-      sR = (s + p).subString(0, p.length()) # change variable
+      sR = (s + p).subString(0, len(p)) # change variable
   return sR
+
+main()

--- a/test/files/julia-set.cs
+++ b/test/files/julia-set.cs
@@ -1,6 +1,6 @@
 // C# with Elan 2.0.0-alpha1
 
-// After image is displayed, press: &nbsp;
+// After image is displayed, press:  
 
 // - z to zoom in, x to zoom out
 
@@ -8,7 +8,7 @@
 
 // - g, j and y, h to change shape
 
-// &nbsp;
+//  
 
 // Acknowledgements:
 

--- a/test/files/julia-set.elan
+++ b/test/files/julia-set.elan
@@ -1,4 +1,4 @@
-# 3bfba459574684ef28c7244d15a44caeeb2de5e527d71bcf124a57ed26e8ea1c Elan 2.0.0-alpha1 valid
+# 7b3957801c9fb8d120e510e09d95b4799cb9a2efededbef09f9fc1b4d959cc0c Elan 2.0.0-alpha1 valid
 
 # After image is displayed, press: 
 # - z to zoom in, x to zoom out

--- a/test/files/julia-set.java
+++ b/test/files/julia-set.java
@@ -1,6 +1,6 @@
 // Java with Elan 2.0.0-alpha1
 
-// After image is displayed, press: &nbsp;
+// After image is displayed, press:  
 
 // - z to zoom in, x to zoom out
 
@@ -8,7 +8,7 @@
 
 // - g, j and y, h to change shape
 
-// &nbsp;
+//  
 
 // Acknowledgements:
 

--- a/test/files/julia-set.py
+++ b/test/files/julia-set.py
@@ -1,6 +1,6 @@
 # Python with Elan 2.0.0-alpha1
 
-# After image is displayed, press: &nbsp;
+# After image is displayed, press:  
 
 # - z to zoom in, x to zoom out
 
@@ -8,7 +8,7 @@
 
 # - g, j and y, h to change shape
 
-# &nbsp;
+#  
 
 # Acknowledgements:
 
@@ -119,3 +119,5 @@ width = 200 # constant
 height = 150 # constant
 
 nmax = 360 # constant
+
+main()

--- a/test/files/julia-set.vb
+++ b/test/files/julia-set.vb
@@ -1,6 +1,6 @@
 ' VB.NET with Elan 2.0.0-alpha1
 
-' After image is displayed, press: &nbsp;
+' After image is displayed, press:  
 
 ' - z to zoom in, x to zoom out
 
@@ -8,7 +8,7 @@
 
 ' - g, j and y, h to change shape
 
-' &nbsp;
+'  
 
 ' Acknowledgements:
 

--- a/test/files/snake-fp.elan
+++ b/test/files/snake-fp.elan
@@ -1,4 +1,4 @@
-# c80fbe2840fb435915dae5c67f817926e674b07847e0619128ead5c97c304533 Elan 2.0.0-alpha1 valid
+# 0fe82350996d01d97aace6e34e26af4ca8e9fa6f7da89005255f9cea4576aa2f Elan 2.0.0-alpha1 valid
 
 # Use the W,A,S,D keys to change Snake direction
 main

--- a/test/files/snake-fp.py
+++ b/test/files/snake-fp.py
@@ -31,7 +31,7 @@ def graphicsPut(graphics: list[list[int]], x: int, y: int, colour: int) -> list[
   return graphics.withSet(x, graphics[x].withSet(y, colour))
 
 def score(g: Game) -> int: # function
-  return g.body.length() - 2
+  return len(g.body) - 2
 
 def moveSnake(g: Game) -> Game: # function
   k = g.key # variable definition
@@ -43,7 +43,7 @@ def moveSnake(g: Game) -> Game: # function
 
 def eatAppleIfPoss(g: Game) -> Game: # function
   tail = g.body[0] # variable definition
-  moveTail = g.body.subList(1, g.body.length()) # variable definition
+  moveTail = g.body.subList(1, len(g.body)) # variable definition
   return if(headOverApple(g), g.withNewApple(), g.withPriorTail(tail).withBody(moveTail))
 
 def headOverApple(g: Game) -> bool: # function
@@ -266,3 +266,5 @@ def test_newGame(self) -> None:
   self.assertEqual(game.priorTail, Square(0, 0))
   self.assertEqual(game.key, "d")
   self.assertEqual(game.isOn, True)
+
+main()

--- a/test/parse-source-and-generate-html.test.ts
+++ b/test/parse-source-and-generate-html.test.ts
@@ -203,35 +203,35 @@ suite("Parse source and generate Html", () => {
       `./out/test/files/snake-OOP.cs`,
       `./out/test/files/snake-OOP.java`,
     );
-    test("Snake FP", async () => {
-      await assertGeneratesHtmlSourceAndExportFiles(
-        `./out/test/files/snake-fp.elan`,
-        ``,
-        `./out/test/files/snake-fp.py`,
-        `./out/test/files/snake-fp.vb`,
-        `./out/test/files/snake-fp.cs`,
-        `./out/test/files/snake-fp.java`,
-      );
-    });
-    test("Date/Time", async () => {
-      await assertGeneratesHtmlSourceAndExportFiles(
-        `./out/test/files/date-time.elan`,
-        ``,
-        `./out/test/files/date-time.py`,
-        `./out/test/files/date-time.vb`,
-        `./out/test/files/date-time.cs`,
-        `./out/test/files/date-time.java`,
-      );
-    });
-    test("Julia set", async () => {
-      await assertGeneratesHtmlSourceAndExportFiles(
-        `./out/test/files/julia-set.elan`,
-        ``,
-        `./out/test/files/julia-set.py`,
-        `./out/test/files/julia-set.vb`,
-        `./out/test/files/julia-set.cs`,
-        `./out/test/files/julia-set.java`,
-      );
-    });
+  });
+  test("Snake FP", async () => {
+    await assertGeneratesHtmlSourceAndExportFiles(
+      `./out/test/files/snake-fp.elan`,
+      ``,
+      `./out/test/files/snake-fp.py`,
+      `./out/test/files/snake-fp.vb`,
+      `./out/test/files/snake-fp.cs`,
+      `./out/test/files/snake-fp.java`,
+    );
+  });
+  test("Date/Time", async () => {
+    await assertGeneratesHtmlSourceAndExportFiles(
+      `./out/test/files/date-time.elan`,
+      ``,
+      `./out/test/files/date-time.py`,
+      `./out/test/files/date-time.vb`,
+      `./out/test/files/date-time.cs`,
+      `./out/test/files/date-time.java`,
+    );
+  });
+  test("Julia set", async () => {
+    await assertGeneratesHtmlSourceAndExportFiles(
+      `./out/test/files/julia-set.elan`,
+      ``,
+      `./out/test/files/julia-set.py`,
+      `./out/test/files/julia-set.vb`,
+      `./out/test/files/julia-set.cs`,
+      `./out/test/files/julia-set.java`,
+    );
   });
 });


### PR DESCRIPTION
In `test/parse-source-and-generate-html.test.ts`, I think a couple of brackets got put in the wrong place by mistake which results in three files being skipped in the export tests. I assume it's a mistake because there is no comment saying "skip these for now" or anything.

- test/files/snake-fp.elan
- test/files/date-time.elan
- test/files/julia-set.elan

I am particularly keen to see date-time included because it is nice and simple and I almost have the Python export for it working. I have moved the brackets in `test/parse-source-and-generate-html.test.ts` back to (fingers crossed) the correct place. I had to update a lot of the expected output from these three files because the processing has moved on in the last few weeks, and these files have not been updated, because the discrepancies produced no test failures.