### PR TITLE
Library function translation moving parameters for Python #2813

### DIFF
--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -122,6 +122,7 @@ export class LanguagePython extends LanguageAbstract {
     } else if (frame instanceof Else) {
       html = `<el-kw>${this.ELSE}</el-kw>:`;
     } else if (frame instanceof Enum) {
+      this.importEnum = true;
       html = `${frame.name.renderAsHtml()} = <el-type>Enum</el-type>('${frame.name.renderAsHtml()}', '${frame.values.renderAsHtml()}')`;
     } else if (frame instanceof GlobalComment) {
       html = `<el-kw>${this.COMMENT_MARKER} </el-kw>${frame.text.renderAsHtml()}`;
@@ -167,7 +168,9 @@ export class LanguagePython extends LanguageAbstract {
     } else if (frame instanceof InterfaceFrame) {
       html = `<el-kw>${this.CLASS} </el-kw><el-type>${frame.name.renderAsHtml()}</el-type>${this.abstractInheritance(frame)}`;
     } else if (frame instanceof MainFrame) {
+      this.importEnum = false;
       this.importMath = false; // reset at start of file
+      this.polyfillsUsed = {};
       html = `<el-kw>${this.DEF} </el-kw><el-method>main</el-method>() -> <el-kw>${this.NONE}</el-kw>:`;
     } else if (frame instanceof ProcedureMethod) {
       html = `<el-kw>${this.DEF} </el-kw>${frame.name.renderAsHtml()}(${this.paramsListAsHtml(frame, frame.params)}) -> <el-kw>${this.NONE}</el-kw>:`;
@@ -203,7 +206,17 @@ export class LanguagePython extends LanguageAbstract {
 
   renderFileImportsAsHtml(): string {
     // no HTML needed here as it is actually only used for export
-    return this.importMath ? "import math\n\n" : "";
+    let result = "";
+    result += this.importEnum ? "import enum\n" : "";
+    result += this.importMath ? "import math\n" : "";
+    // blank line only if we have any imports
+    result += this.importEnum || this.importMath ? "\n" : "";
+    let extra = "";
+    for (const p in this.polyfillsUsed) {
+      result += this.polyfillTable[p];
+      extra = "\n"; // extra newline if we have any polyfills here
+    }
+    return result + extra;
   }
 
   renderFileTrailerAsHtml(): string {
@@ -220,7 +233,9 @@ export class LanguagePython extends LanguageAbstract {
     let result = expr.replace(regexp, this.lookupmath);
 
     // non-math functions which are dot methods and stay dot methods
-    result = this.translateDotMethods(result);
+    // or standalone and stay standalone
+    // ie just a name change required
+    result = this.translatePlainMethods(result);
 
     // extension methods (dot methods) which become standalone functions in Python
     // and the object becomes the argument
@@ -228,9 +243,19 @@ export class LanguagePython extends LanguageAbstract {
     // or the object becomes the first argument
     // eg num.round(3) becomes round(num, 3)
     result = this.translateExtension(result);
+
+    // standalone functions with parameters which need moving
+    result = this.translateStandaloneWithParams(result);
+
+    result = this.translateOddities(result);
+    // Not sure if I should be acting on expr or result.
+    // There should be no overlap between any of the Elan or Python names.
+    this.registerPolyfills(expr);
+
     return result;
   }
 
+  private importEnum = false;
   private importMath = false;
   private mathExceptions: { [propName: string]: string } = {
     pow: "pow",
@@ -255,7 +280,10 @@ export class LanguagePython extends LanguageAbstract {
     return `${p1}${result}${p3}`;
   };
 
-  private dotMethodTable: { [propName: string]: string } = {
+  private plainMethodTable: { [propName: string]: string } = {
+    unicode: "chr",
+    rangeInSteps: "range",
+    indexOf: "find", // "index" raises an exception on not found
     upperCase: "upper",
     lowerCase: "lower",
     trim: "strip",
@@ -263,13 +291,17 @@ export class LanguagePython extends LanguageAbstract {
   // omitting split: "split" as the name is the same
 
   // non-math functions which are dot methods and stay dot methods
+  // or stanalone and stay standalone
   // these just need the name changing, and no import statement is needed
   // could use regexp lookahead and lookbehind to handle the tags
   // but I am doing it the way I know for now
-  private translateDotMethods(expr: string): string {
+  private translatePlainMethods(expr: string): string {
     return expr.replace(
-      /(${this.METHOPTAG})(${Object.keys(this.dotMethodTable).join("|")})(${this.METHCLTAG})/g,
-      (_match, p1, p2, p3) => `${p1}${this.dotMethodTable[p2]}${p3}`,
+      new RegExp(
+        `(${this.METHOPTAG})(${Object.keys(this.plainMethodTable).join("|")})(${this.METHCLTAG})`,
+        "g",
+      ),
+      (_match, p1, p2, p3) => `${p1}${this.plainMethodTable[p2]}${p3}`,
     );
   }
 
@@ -292,6 +324,7 @@ export class LanguagePython extends LanguageAbstract {
     isNaN: "math.isnan",
     isInfinite: "math.isinf",
     round: "round",
+    withAppend: "withAppendPy", // adjusted in a later pass
   };
 
   // Dot methods which translate to standalone functions
@@ -309,7 +342,7 @@ export class LanguagePython extends LanguageAbstract {
       // Adjust the match position to take account of the fact that the part
       // before the match may have already changed in length, but the part
       // after the match has not changed.
-      // pos2 is the position of the function name in "result".
+      // pos2 is the position of the function name (with its tags) in "result".
       const pos2 = match.index + result.length - expr.length;
       const funcName = match[2]; // second set of brackets is the function name
       // convert the quotes so we can distinguish the two ends of a string
@@ -413,6 +446,180 @@ export class LanguagePython extends LanguageAbstract {
     }
     // ran off end of string
     throw new Error("No match");
+  }
+
+  // Table for functions with parameters that need moving
+  // Add brackets round the whole expression
+  // if there may be a higher-priority operator adjacent
+  private standaloneTable: { [propName: string]: string } = {
+    // there is no confusion with "if" statements
+    // as this code is only run for expressions
+    if: "($1 if $0 else $2)",
+    divAsInt: "math.floor(($0)/($1))",
+    divAsFloat: "(($0)/($1))",
+    createList: "[$1 for n in range($0)]",
+    bitAnd: "(($0) & ($1))",
+    bitOr: "($0 | $1)",
+    bitXor: "($0 ^ $1)",
+    bitNot: "(~$0)",
+    bitShiftL: "($0 &lt;&lt; $1)",
+    bitShiftR: "(($0 & (1&lt;&lt;32)-1) &gt;&gt; $1)",
+    // copy TBD
+    subString: "[$0:$1]",
+    printNoLine: "print($0, end='')",
+    withAppendPy: "($0 + [($1)])",  // list + [value]
+  };
+
+  private translateStandaloneWithParams(expr: string): string {
+    // We use the same algorithm more or less as translateExtension
+    // (dot methods which translate to standalone functions;
+    //  the object in obj.length() moves to the right in the string).
+    // The twist is that this time there are arguments which move to the left
+    // in the string, and hence we need to find the function calls in reverse order
+    // from right to left so that the arguments get translated before the function call.
+    // Otherwise it is hard to keep track of where we are in the "result" string.
+    // There is no direct mechanism that I can find in JavaScript to run a //g regular expression
+    // match from right to left.
+    // But we can do it in about 3 extra lines of code by:
+    // - reversing the string to be searched
+    // - reversing the string from which we construct the regular expression
+    // - reversing the matched string after the match
+    // - adjusting the returned index, where the string was found
+    // this may be a bit inefficient -- it reverses the string repeatedly
+    // but most of the time it doesn't find anything so only does it once
+    // As this is a one-line function, let's make it local for the moment
+    const strRev = (s: string) => [...s].reverse().join("");
+    let result = expr;
+    // brackets the wrong way round as the string is reversed!
+    // easier to debug if I changed the brackets on the fly
+    const regexp = new RegExp(
+      strRev(
+        `)${this.METHOPTAG}()${Object.keys(this.standaloneTable).join("|")}()${this.METHCLTAG}(`,
+      ),
+      "g",
+    );
+    let match;
+    // We scan through the original line "expr" looking for function names to convert
+    // in one pass so that we don't scan the same area twice, in case the name is the same.
+    // note assignment to "match" not a comparison
+    while ((match = regexp.exec(strRev(expr)))) {
+      const funcName = strRev(match[2]); // second set of brackets is the function name
+      const funcLength = match[0].length; // length of function name with its tags
+      // Adjust the match position to take account of the fact that the part
+      // after the match may have already changed in length, but the part
+      // before the match has not changed.
+      // pos2 is the position of the function name (with its tags) in "result".
+      const pos2 = expr.length - match.index - funcLength;
+
+      // see previous comment
+      // this needs to be a separate function one day
+      const working = result
+        .replaceAll(this.OPENQUOTE, "z")
+        .replaceAll(this.CLOSEQUOTE, "z")
+        .replaceAll('"<', this.OPENQUOTE + "<")
+        .replaceAll('>"', ">" + this.CLOSEQUOTE)
+        .replaceAll("</", "<@");
+
+      // move beyond the bracket following the function name
+      const pos1 = pos2 + funcLength + 1;
+      // fetch the aguments.  prms is array of strings
+      // returns { prms: params, end: index }
+      const params = this.getparams(working, pos1);
+
+      // replace the call and the arguments with the replacement string from the table
+      // the arguments may have already been rewritten earlier.
+
+      // we don't check that we have the right number of arguments
+      // just drop in as many as we have placeholders for
+
+      const replacement = this.standaloneTable[funcName];
+      // for dot methods eg subString we need to remove the dot
+      const dotAdjust = pos2 > 0 && result[pos2 - 1] === "." ? 1 : 0;
+      // and now put it all together
+      result =
+        result.substring(0, pos2 - dotAdjust) + // up to the function name
+        replacement.replace(/\$(\d)/g, (_match, p1) =>
+          result.substring(params.prms[+p1][0], params.prms[+p1][1]),
+        ) + // params in expression
+        result.substring(params.end + 1); // rest of the string (+1 for trailing bracket on params)
+      if (replacement.startsWith("math.")) {
+        this.importMath = true;
+      }
+    } // while regexp.exec
+    return result;
+  }
+
+  // start points to first character of params, after the open bracket
+  // returns array of [start, end] positions for the params and the offset of the end
+  // can't return the actual strings as we are working on the "working" version
+  // with adjusted quotes
+  private getparams(text: string, start: number): { prms: number[][]; end: number } {
+    const params = []; // not really a constant, it gets elements added
+    const lup = { close: ")", nest: this.OPENQUOTE + "([", sep: ",)" };
+    let index = start;
+    let pstart = index;
+    while (index < text.length) {
+      const c = text[index];
+      if (lup.sep.includes(c)) {
+        params.push([pstart, index]);
+        pstart = index + 2; // for next param, beyond the comma and space
+      }
+      if (c === lup.close) {
+        return { prms: params, end: index };
+      }
+      if (lup.nest.includes(c)) {
+        index = this.findmatch(text, index, 1);
+        // and continue after the nested element
+      }
+      // else an ordinary character, take no action
+      index++;
+    }
+    // ran off end of string
+    throw new Error("Bad param syntax");
+  }
+
+  private polyfillTable: { [propName: string]: string } = {
+    clock: `import time
+def clock():
+  return int(time.time()*1000)
+`,
+    parseAsInt: `def parseAsInt(s):
+  try:
+    n = int(s)
+  except ValueError:
+    return (False, 0)
+  return (True, n)
+`,
+  };
+
+  private polyfillsUsed: { [f: string]: boolean } = {};
+
+  private registerPolyfills(expr: string): void {
+    let match;
+    const regexp = new RegExp(
+      `(${this.METHOPTAG})(${Object.keys(this.polyfillTable).join("|")})(${this.METHCLTAG})`,
+      "g",
+    );
+    while ((match = regexp.exec(expr))) {
+      const funcName = match[2];
+      this.polyfillsUsed[funcName] = true;
+    }
+  }
+
+  private translateOddities(expr: string): string {
+    // the items in a tuple
+    let result = expr.replace(/\.<el-id>item_(\d)<\/el-id>/g, "[$1]");
+
+    // .equals --> ' == '
+    // this can be table-driven one day
+    // note leading dot included in string to replace
+    // we keep the brackets round the right hand side in case it is an expression
+    // with an operator with lower priority than "==", though there are not many
+    result = result.replace(
+      new RegExp(`.(${this.METHOPTAG})(equals)(${this.METHCLTAG})`, "g"),
+      (_match, _p1, _p2, _p3) => ` == `,
+    );
+    return result;
   }
 
   private DEF = "def";

--- a/test/files/binary-search.py
+++ b/test/files/binary-search.py
@@ -1,11 +1,13 @@
 # Python with Elan 2.0.0-alpha1
 
+import math
+
 def main() -> None:
   fruit = ["apple", "avocado", "banana", "blueberry", "cherry", "fig", "grape", "kiwi", "lemon", "lychee", "mango", "orange", "papaya", "peach", "pear", "pineapple", "plum", "raspberry", "strawberry", "watermelon"] # variable definition
   done = False # variable definition
   while not done:
     wanted = input("What type of fruit do you want ('x' to exit)? ") # variable definition
-    if wanted.equals("x"):
+    if wanted == ("x"):
       done = True # change variable
     else:
       result = binarySearch(fruit, wanted) # variable definition
@@ -17,9 +19,9 @@ def main() -> None:
 def binarySearch(li: list[str], item: str) -> bool: # function
   result = False # variable definition
   if len(li) > 0:
-    mid = divAsInt(len(li), 2) # constant
+    mid = math.floor((len(li))/(2)) # constant
     value = li[mid] # variable definition
-    if item.equals(value):
+    if item == (value):
       result = True # change variable
     elif item.isBefore(value):
       result = binarySearch(li.subList(0, mid), item) # change variable

--- a/test/files/collatz.py
+++ b/test/files/collatz.py
@@ -1,5 +1,7 @@
 # Python with Elan 2.0.0-alpha1
 
+import math
+
 # A program to investigate the Collatz Conjecture
 
 # https://en.wikipedia.org/wiki/Collatz_conjecture
@@ -15,7 +17,7 @@ def main() -> None:
     while x > 1:
       # Collatz sequence
       if (x % 2) == 0:
-        x = divAsInt(x, 2) # change variable
+        x = math.floor((x)/(2)) # change variable
       else:
         x = x*3 + 1 # change variable
       if x > max:
@@ -24,7 +26,7 @@ def main() -> None:
       # draw what we have got so far, scaled to the canvas
       vg = list[VectorGraphic]() # variable definition
       for i in range(0, len(p) - 1):
-        vg = vg.withAppend((LineVG()).withX1(scx(i, p)).withY1(scy(p[i], max)).withX2(scx(i + 1, p)).withY2(scy(p[i + 1], max)).withStrokeWidth(1)) # change variable
+        vg = (vg + [((LineVG()).withX1(scx(i, p)).withY1(scy(p[i], max)).withX2(scx(i + 1, p)).withY2(scy(p[i + 1], max)).withStrokeWidth(1))]) # change variable
       displayVectorGraphics(vg) # call procedure
       print(x)
       sleep_ms(100) # call procedure
@@ -33,7 +35,7 @@ def main() -> None:
 # scale x.  We pass in p just to get its length
 
 def scx(i: int, p: list[int]) -> float: # function
-  return divAsFloat(i*100, len(p))
+  return ((i*100)/(len(p)))
 
 # scale y
 
@@ -42,7 +44,7 @@ def scx(i: int, p: list[int]) -> float: # function
 # subtract 1 so that 1 is always at the same place on the canvas
 
 def scy(pi: int, max: int) -> float: # function
-  return 70 - divAsFloat((pi - 1)*65, (max - 1))
+  return 70 - (((pi - 1)*65)/((max - 1)))
 
 grey = 0x808080 # constant
 

--- a/test/files/date-time.py
+++ b/test/files/date-time.py
@@ -2,27 +2,37 @@
 
 import math
 
+import time
+def clock():
+  return int(time.time()*1000)
+def parseAsInt(s):
+  try:
+    n = int(s)
+  except ValueError:
+    return (False, 0)
+  return (True, n)
+
 def main() -> None:
   reply = "" # variable definition
-  while not reply.upperCase().equals("Q"):
+  while not reply.upper() == ("Q"):
     reply = input("RETURN for time now or Unix time (positive integer) or Q to quit") # change variable
-    if reply.equals(""):
-      now = divAsInt(clock(), 1000) # constant
+    if reply == (""):
+      now = math.floor((clock())/(1000)) # constant
       print(now)
       print(getDate(now))
     else:
       td = parseAsInt(reply) # variable definition
-      if td.item_0 and (td.item_1 >= 0):
-        print(getDate(td.item_1))
+      if td[0] and (td[1] >= 0):
+        print(getDate(td[1]))
 
 def getDate(unixSecs: int) -> str: # function
   dt = dateTime(unixSecs) # variable definition
-  hour = dt.item_0 # constant
-  minute = dt.item_1 # constant
-  second = dt.item_2 # constant
-  days = dt.item_3 # constant
-  year = dt.item_4 # constant
-  weekday = dt.item_5 # constant
+  hour = dt[0] # constant
+  minute = dt[1] # constant
+  second = dt[2] # constant
+  days = dt[3] # constant
+  year = dt[4] # constant
+  weekday = dt[5] # constant
   z2 = "00" # constant
   h = padLwithZero(hour) # constant
   m = padLwithZero(minute) # constant
@@ -30,8 +40,8 @@ def getDate(unixSecs: int) -> str: # function
   startDays = getStartDays() # variable definition
   startDaysL = startDaysList(year, startDays) # variable definition
   month_day = monthDay(startDaysL, (days % startDays[12])) # variable definition
-  month = month_day.item_0 # constant
-  day = month_day.item_1 # constant
+  month = month_day[0] # constant
+  day = month_day[1] # constant
   dayName = getWeekdayName(weekday) # constant
   d = padLwithZero(day) # constant
   monthName = getMonthName(month) # constant
@@ -42,11 +52,11 @@ def test_getDate(self) -> None:
 
 def dateTime(unixSecs: int) -> tuple[int, int, int, int, int, int]: # function
   # get separate values from Unix time
-  hour = (divAsInt(divAsInt(unixSecs, 60), 60) % 24) # constant
-  minute = divAsInt(unixSecs, 60) % 60 # constant
+  hour = (math.floor((math.floor((unixSecs)/(60)))/(60)) % 24) # constant
+  minute = math.floor((unixSecs)/(60)) % 60 # constant
   second = (unixSecs % 60) # constant
   # days and years from Unix epoch
-  unixDay = divAsInt(unixSecs, daySecs) # constant
+  unixDay = math.floor((unixSecs)/(daySecs)) # constant
   years = math.floor(((unixDay + 1)/365.24)) # constant
   # this year and weekday
   year = unixYear + years # constant
@@ -77,7 +87,7 @@ def leap(year: int) -> bool: # function
   leapYear = False # variable definition
   if (year % 4) == 0:
     leapYear = True # change variable
-    if ((year % 100) == 0) and ((divAsInt(year, 100) % 4) != 0):
+    if ((year % 100) == 0) and ((math.floor((year)/(100)) % 4) != 0):
       leapYear = False # change variable
   return leapYear
 
@@ -151,11 +161,11 @@ def pad(d: str, p: str, s: str) -> str: # function
   # s: input string
   sR = s # variable definition
   if len(p) > len(s):
-    if d.upperCase().equals("L"):
+    if d.upper() == ("L"):
       ps = p + s # constant
-      sR = ps.subString(len(ps) - len(p), len(ps)) # change variable
-    elif d.upperCase().equals("R"):
-      sR = (s + p).subString(0, len(p)) # change variable
+      sR = ps[len(ps) - len(p):len(ps)] # change variable
+    elif d.upper() == ("R"):
+      sR = (s + p)[0:len(p)] # change variable
   return sR
 
 main()

--- a/test/files/julia-set.py
+++ b/test/files/julia-set.py
@@ -29,11 +29,11 @@ def allpoints(p: Coords) -> list[VectorGraphic]: # function
   for xp in range(0, width + 1):
     for yp in range(0, height + 1):
       # scale and centre
-      n = onepoint(divAsFloat(divAsFloat(xp - width, 2), p.scale - p.xoff), divAsFloat(divAsFloat(yp - height, 2), p.scale - p.yoff), nmax, p) # constant
+      n = onepoint(((((xp - width)/(2)))/(p.scale - p.xoff)), ((((yp - height)/(2)))/(p.scale - p.yoff)), nmax, p) # constant
       # colour depends on how many iterations were done for that point
-      col = if(n == nmax, 0xffffff, ((n*0x010201) % 0xffffff)) # constant
-      rect = (RectangleVG()).withX(divAsFloat(xp, 2)).withY(divAsFloat(yp, 2)).withWidth(0.5).withHeight(0.5).withFillColour(col).withStrokeWidth(0.25) # variable definition
-      vg2 = vg2.withAppend(rect) # change variable
+      col = (0xffffff if n == nmax else ((n*0x010201) % 0xffffff)) # constant
+      rect = (RectangleVG()).withX(((xp)/(2))).withY(((yp)/(2))).withWidth(0.5).withHeight(0.5).withFillColour(col).withStrokeWidth(0.25) # variable definition
+      vg2 = (vg2 + [(rect)]) # change variable
   return vg2
 
 def onepoint(x: float, y: float, maxnum: int, p: Coords) -> int: # function
@@ -78,26 +78,26 @@ class Coords
     while not changed:
       k = getKey() # variable definition
       # loop because more than one key may have been pressed
-      while not k.equals(""):
-        if k.equals("z"):
+      while not k == (""):
+        if k == ("z"):
           self.scale = self.scale*1.2 # change variable
-        elif k.equals("x"):
+        elif k == ("x"):
           self.scale = self.scale/1.2 # change variable
-        elif k.equals("ArrowUp"):
+        elif k == ("ArrowUp"):
           self.yoff = self.yoff + panstep # change variable
-        elif k.equals("ArrowDown"):
+        elif k == ("ArrowDown"):
           self.yoff = self.yoff - panstep # change variable
-        elif k.equals("ArrowLeft"):
+        elif k == ("ArrowLeft"):
           self.xoff = self.xoff + panstep # change variable
-        elif k.equals("ArrowRight"):
+        elif k == ("ArrowRight"):
           self.xoff = self.xoff - panstep # change variable
-        elif k.equals("g"):
+        elif k == ("g"):
           self.jx = self.jx + jstep # change variable
-        elif k.equals("j"):
+        elif k == ("j"):
           self.jx = self.jx - jstep # change variable
-        elif k.equals("y"):
+        elif k == ("y"):
           self.jy = self.jy + jstep # change variable
-        elif k.equals("h"):
+        elif k == ("h"):
           self.jy = self.jy - jstep # change variable
           # for autocomplete in the RHS expression, don't type "property"
         else:

--- a/test/files/life.py
+++ b/test/files/life.py
@@ -22,27 +22,27 @@ def blackOrWhite(random: float) -> int: # function
   return result
 
 def north(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell.item_0 # constant
-  y = cell.item_1 # constant
-  y2 = if(y == 0, 29, y - 1) # constant
+  x = cell[0] # constant
+  y = cell[1] # constant
+  y2 = (29 if y == 0 else y - 1) # constant
   return (x, y2)
 
 def south(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell.item_0 # constant
-  y = cell.item_1 # constant
-  y2 = if(y == 29, 0, y + 1) # constant
+  x = cell[0] # constant
+  y = cell[1] # constant
+  y2 = (0 if y == 29 else y + 1) # constant
   return (x, y2)
 
 def east(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell.item_0 # constant
-  y = cell.item_1 # constant
-  x2 = if(x == 39, 0, x + 1) # constant
+  x = cell[0] # constant
+  y = cell[1] # constant
+  x2 = (0 if x == 39 else x + 1) # constant
   return (x2, y)
 
 def west(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell.item_0 # constant
-  y = cell.item_1 # constant
-  x2 = if(x == 0, 39, x - 1) # constant
+  x = cell[0] # constant
+  y = cell[1] # constant
+  x2 = (39 if x == 0 else x - 1) # constant
   return (x2, y)
 
 def northEast(cell: tuple[int, int]) -> tuple[int, int]: # function
@@ -64,8 +64,8 @@ def neighbourCells(x: int, y: int) -> list[tuple[int, int]]: # function
 def liveNeighbours(grid: list[list[int]], x: int, y: int) -> int: # function
   count = 0 # variable definition
   for cell in neighbourCells(x, y):
-    cx = cell.item_0 # constant
-    cy = cell.item_1 # constant
+    cx = cell[0] # constant
+    cy = cell[1] # constant
     if grid[cx][cy] == black:
       count = count + 1 # change variable
   return count

--- a/test/files/pathfinder.py
+++ b/test/files/pathfinder.py
@@ -1,5 +1,6 @@
 # Python with Elan 2.0.0-alpha1
 
+import enum
 import math
 
 def main() -> None:
@@ -27,10 +28,10 @@ def runSolver(gr: list[list[int]], start: Point, destination: Point, rocks: list
     gr2 = addVisited(gr2, solver.getLastVisited()) # change variable
     displayBlocks(gr2) # call procedure
     sleep_ms(0) # call procedure
-  if solver.getLastVisited().equals(destination):
+  if solver.getLastVisited() == (destination):
     rl = solver.getRouteAndLength() # variable definition
-    route = rl.item_0 # variable definition
-    length = rl.item_1 # constant
+    route = rl[0] # variable definition
+    length = rl[1] # constant
     gr2 = addRoute(gr2, route) # change variable
     displayBlocks(gr2) # call procedure
     printNoLine(f"Length of route: {round(length, 2)} ") # call procedure
@@ -41,11 +42,11 @@ def createRocksAndNodes(percentRocks: int, rocks: list[Point], nodes: list[Node]
   for x in range(0, 40):
     for y in range(1, 30):
       p = Point(x, y) # variable definition
-      if p.equals(start):
+      if p == (start):
         nodes.append(Node(p, 0, p.minDistTo(dest))) # call procedure
-      elif p.equals(dest):
+      elif p == (dest):
         nodes.append(Node(p, infinity, 0)) # call procedure
-      elif random() < divAsFloat(percentRocks, 100):
+      elif random() < ((percentRocks)/(100)):
         rocks.append(p) # call procedure
       else:
         nodes.append(Node(p, infinity, p.minDistTo(dest))) # call procedure
@@ -101,7 +102,7 @@ class Solver
   def visitNextPoint(self: Solver) -> None: # procedure
     self.updateNeighbours() # call procedure
     self.current = self.nextNodeToVisit() # change variable
-    if (self.current.isEmpty or (self.current.point.equals(self.destination))):
+    if (self.current.isEmpty or (self.current.point == (self.destination))):
       self.running = False # change variable
     else:
       current = self.current # variable definition
@@ -122,11 +123,11 @@ class Solver
       node = self.getNodeFor(p) # variable definition
       point = node.point # variable definition
       if not point.isEmpty:
-        neighbours = neighbours.withAppend(node) # change variable
+        neighbours = (neighbours + [(node)]) # change variable
     return neighbours
   def getNodeFor(self: Solver, p: Point) -> Node: # function
-    matches = self.nodes.filter(lambda n: Node => n.point.equals(p)) # variable definition
-    return if(len(matches) == 1, matches.head(), emptyNode())
+    matches = self.nodes.filter(lambda n: Node => n.point == (p)) # variable definition
+    return (matches.head() if len(matches) == 1 else emptyNode())
   def getLastVisited(self: Solver) -> Point: # function
     return self.current.point
   def nextNodeToVisit(self: Solver) -> Node: # function
@@ -154,7 +155,7 @@ class Solver
     route = [self.destination] # variable definition
     length = 0.0 # variable definition
     node = self.getNodeFor(self.destination) # variable definition
-    while not node.point.equals(self.start):
+    while not node.point == (self.start):
       previous = node.via # variable definition
       p = node.point # variable definition
       length = length + p.minDistTo(previous) # change variable

--- a/test/files/roman-numerals-turing-machine.py
+++ b/test/files/roman-numerals-turing-machine.py
@@ -1,5 +1,7 @@
 # Python with Elan 2.0.0-alpha1
 
+import enum
+
 # Turing Machine that converts a Year from decimal to roman numerals
 
 # Run the program, enter the number to convert and watch the machine in action.
@@ -27,7 +29,7 @@ def main() -> None:
     print(f"State: {tm.currentState}")
     print(f"Rule applied: {str(rule)}")
     sleep_ms(40) # call procedure
-  print(f"The roman numeral equivalent for {dec} is {tm.tape.trim()}")
+  print(f"The roman numeral equivalent for {dec} is {tm.tape.strip()}")
 
 initState = "init" # constant
 
@@ -53,20 +55,20 @@ class TuringMachine
   def setTape(self: TuringMachine, tape: str) -> None: # procedure
     self.tape = tape # change variable
   def append(self: TuringMachine, rule: Rule) -> None: # procedure
-    self.rules = self.rules.withAppend(rule) # change variable
+    self.rules = (self.rules + [(rule)]) # change variable
   def singleStep(self: TuringMachine) -> None: # procedure
     rule = self.findMatchingRule() # variable definition
     self.execute(rule) # call procedure
   def isHalted(self: TuringMachine) -> bool: # function
-    return self.currentState.equals(self.haltState)
+    return self.currentState == (self.haltState)
   def findMatchingRule(self: TuringMachine) -> Rule: # function
-    matches = self.rules.filter(lambda r: Rule => (r.currentState.equals(self.currentState)) and (r.currentSymbol.equals(self.tape[self.headPosition]))) # variable definition
+    matches = self.rules.filter(lambda r: Rule => (r.currentState == (self.currentState)) and (r.currentSymbol == (self.tape[self.headPosition]))) # variable definition
     if len(matches) == 0:
       raise ElanRuntimeError("f"No rule matching state {self.currentState} and symbol {self.tape[self.headPosition]}"")
     return matches.head()
   def write(self: TuringMachine, newSymbol: str) -> None: # procedure
     hp = self.headPosition # constant
-    self.tape = self.tape.subString(0, hp) + newSymbol + self.tape.subString(hp + 1, len(self.tape)) # change variable
+    self.tape = self.tape[0:hp] + newSymbol + self.tape[hp + 1:len(self.tape)] # change variable
   def execute(self: TuringMachine, rule: Rule) -> None: # procedure
     self.currentState = rule.nextState # change variable
     self.write(rule.writeSymbol) # call procedure

--- a/test/files/snake-OOP.py
+++ b/test/files/snake-OOP.py
@@ -1,5 +1,7 @@
 # Python with Elan 2.0.0-alpha1
 
+import enum
+
 # Use the W,A,S,D keys to change Snake direction
 
 def main() -> None:
@@ -35,32 +37,32 @@ class Snake
     body = self.body # variable definition
     body.append(self.head) # call procedure
     self.head = self.head.getAdjacentSquare(self.currentDir) # change variable
-    if self.head.equals(apple.location):
+    if self.head == (apple.location):
       apple.newRandomPosition(self) # call procedure
     else:
       self.body = self.body.subList(1, len(self.body)) # change variable
   def updateBlocks(self: Snake, blocks: list[list[int]]) -> None: # procedure
     blocks[self.head.x][self.head.y] = green # change variable
-    if not self.body[0].equals(self.priorTail):
+    if not self.body[0] == (self.priorTail):
       blocks[self.priorTail.x][self.priorTail.y] = white # change variable
   def score(self: Snake) -> int: # function
     return len(self.body) - 1
   def bodyCovers(self: Snake, sq: Square) -> bool: # function
     result = False # variable definition
     for seg in self.body:
-      if (seg.equals(sq)):
+      if (seg == (sq)):
         result = True # change variable
     return result
   def gameOver(self: Snake) -> bool: # function
     return self.bodyCovers(self.head) or self.head.hasHitEdge()
   def setDirection(self: Snake, key: str) -> None: # private procedure
-    if key.equals("w"):
+    if key == ("w"):
       self.currentDir = Direction.up # change variable
-    elif key.equals("s"):
+    elif key == ("s"):
       self.currentDir = Direction.down # change variable
-    elif key.equals("a"):
+    elif key == ("a"):
       self.currentDir = Direction.left # change variable
-    elif key.equals("d"):
+    elif key == ("d"):
       self.currentDir = Direction.right # change variable
 
 

--- a/test/files/snake-fp.py
+++ b/test/files/snake-fp.py
@@ -15,16 +15,16 @@ def main() -> None:
   print(f"Game Over! Score: {score(game)}")
 
 def clockTick(g: Game, k: str) -> Game: # function
-  g2 = if(k.equals(""), g, g.withKey(k)) # variable definition
+  g2 = (g if k == ("") else g.withKey(k)) # variable definition
   g3 = moveSnake(g2) # variable definition
   g4 = eatAppleIfPoss(g3) # variable definition
-  return if(gameOver(g4), g4.withIsOn(False), g4)
+  return (g4.withIsOn(False) if gameOver(g4) else g4)
 
 def updateGraphics(g: Game, b: list[list[int]]) -> list[list[int]]: # function
   b2 = graphicsPut(b, g.apple.x, g.apple.y, red) # variable definition
   b3 = graphicsPut(b2, g.head.x, g.head.y, green) # variable definition
   tail = g.body[0] # variable definition
-  tailColour = if(tail.equals(g.priorTail), green, white) # variable definition
+  tailColour = (green if tail == (g.priorTail) else white) # variable definition
   return graphicsPut(b3, tail.x, tail.y, tailColour)
 
 def graphicsPut(graphics: list[list[int]], x: int, y: int, colour: int) -> list[list[int]]: # function
@@ -37,17 +37,17 @@ def moveSnake(g: Game) -> Game: # function
   k = g.key # variable definition
   x = g.head.x # variable definition
   y = g.head.y # variable definition
-  newX = if(k.equals("a"), x - 1, if(k.equals("d"), x + 1, x)) # variable definition
-  newY = if(k.equals("w"), y - 1, if(k.equals("s"), y + 1, y)) # variable definition
-  return g.withBody(g.body.withAppend(g.head)).withHead(Square(newX, newY))
+  newX = (x - 1 if k == ("a") else (x + 1 if k == ("d") else x)) # variable definition
+  newY = (y - 1 if k == ("w") else (y + 1 if k == ("s") else y)) # variable definition
+  return g.withBody((g.body + [(g.head)])).withHead(Square(newX, newY))
 
 def eatAppleIfPoss(g: Game) -> Game: # function
   tail = g.body[0] # variable definition
   moveTail = g.body.subList(1, len(g.body)) # variable definition
-  return if(headOverApple(g), g.withNewApple(), g.withPriorTail(tail).withBody(moveTail))
+  return (g.withNewApple() if headOverApple(g) else g.withPriorTail(tail).withBody(moveTail))
 
 def headOverApple(g: Game) -> bool: # function
-  return g.head.equals(g.apple)
+  return g.head == (g.apple)
 
 def gameOver(g: Game) -> bool: # function
   return g.body.contains(g.head) or hasHitEdge(g)
@@ -78,14 +78,14 @@ class Game
     return ""
   def withNewApple(self: Game) -> Game: # function
     x_rnd2 = self.rnd.nextInt(0, 39) # variable definition
-    x = x_rnd2.item_0 # variable definition
-    rnd2 = x_rnd2.item_1 # variable definition
+    x = x_rnd2[0] # variable definition
+    rnd2 = x_rnd2[1] # variable definition
     y_rnd3 = rnd2.nextInt(0, 29) # variable definition
-    y = y_rnd3.item_0 # variable definition
-    rnd3 = y_rnd3.item_1 # variable definition
+    y = y_rnd3[0] # variable definition
+    rnd3 = y_rnd3[1] # variable definition
     apple2 = Square(x, y) # variable definition
     g2 = self.withApple(apple2).withRnd(rnd3) # variable definition
-    return if(g2.body.contains(apple2), g2.withNewApple(), g2)
+    return (g2.withNewApple() if g2.body.contains(apple2) else g2)
   def withHead(self: Game, value: Square) -> Game: # function
     copyOfThis = copy(self) # variable definition
     copyOfThis.head = value # change variable
@@ -256,7 +256,7 @@ def test_newSquare(self) -> None:
 def test_newGame(self) -> None:
   rnd = Random() # variable definition
   game = Game(rnd) # variable definition
-  totest = game.rnd.equals(rnd) # variable definition
+  totest = game.rnd == (rnd) # variable definition
   self.assertEqual(totest, True)
   self.assertEqual(game.head, Square(22, 15))
   body = game.body # variable definition


### PR DESCRIPTION
[I am happy for this to be merged in to the main branch to keep a single code base.
I wanted to see this approach through just to see how it panned out, but I do wonder if we should actually go back to hooking into the parse nodes, given that this implementation is so complicated. ie not "just a RegEx match and substitution" to quote #2620!]

Moving parameters, Enum, polyfills, `equals`.

The bulk of the new code is for functions where the parameters have to be moved around.

Enum needs more work to actually work.

The polyfills and `equals` are just proof-of-concept. I added functions which are common in the demo programs. The processing of `equals` needs to be made table-driven before adding more functions.

Updated the test *.py files

PS Changed function name `translateDotMethods` to `translatePlainMethods` as it turns out that it works for standalone methods too as long as the translation is also standalone.
Also added `withAppend` as a proof-of-concept.
