### PR TITLE
Back out expression translation #2813

### DIFF
--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -205,6 +205,9 @@ export class LanguagePython extends LanguageAbstract {
   }
 
   renderFileImportsAsHtml(): string {
+    // Change of plan, disable all imports for the moment too
+    return "";
+
     // no HTML needed here as it is actually only used for export
     let result = "";
     result += this.importEnum ? "import enum\n" : "";
@@ -224,6 +227,9 @@ export class LanguagePython extends LanguageAbstract {
   }
 
   translateExpression(expr: string): string {
+    // Change of plan, disable all the expression translation for the moment
+    return expr;
+
     // add "math." to math library functions
     const regexp = new RegExp(
       `(<el-method>)(${languageHelper_mathFunctions.join("|")})(</el-method>)`,

--- a/test/files/binary-search.py
+++ b/test/files/binary-search.py
@@ -1,13 +1,11 @@
 # Python with Elan 2.0.0-alpha1
 
-import math
-
 def main() -> None:
   fruit = ["apple", "avocado", "banana", "blueberry", "cherry", "fig", "grape", "kiwi", "lemon", "lychee", "mango", "orange", "papaya", "peach", "pear", "pineapple", "plum", "raspberry", "strawberry", "watermelon"] # variable definition
   done = False # variable definition
   while not done:
     wanted = input("What type of fruit do you want ('x' to exit)? ") # variable definition
-    if wanted == ("x"):
+    if wanted.equals("x"):
       done = True # change variable
     else:
       result = binarySearch(fruit, wanted) # variable definition
@@ -18,15 +16,15 @@ def main() -> None:
 
 def binarySearch(li: list[str], item: str) -> bool: # function
   result = False # variable definition
-  if len(li) > 0:
-    mid = math.floor((len(li))/(2)) # constant
+  if li.length() > 0:
+    mid = divAsInt(li.length(), 2) # constant
     value = li[mid] # variable definition
-    if item == (value):
+    if item.equals(value):
       result = True # change variable
     elif item.isBefore(value):
       result = binarySearch(li.subList(0, mid), item) # change variable
     else:
-      result = binarySearch(li.subList(mid + 1, len(li)), item) # change variable
+      result = binarySearch(li.subList(mid + 1, li.length()), item) # change variable
   return result
 
 def test_binarySearch(self) -> None:

--- a/test/files/collatz.py
+++ b/test/files/collatz.py
@@ -1,7 +1,5 @@
 # Python with Elan 2.0.0-alpha1
 
-import math
-
 # A program to investigate the Collatz Conjecture
 
 # https://en.wikipedia.org/wiki/Collatz_conjecture
@@ -17,7 +15,7 @@ def main() -> None:
     while x > 1:
       # Collatz sequence
       if (x % 2) == 0:
-        x = math.floor((x)/(2)) # change variable
+        x = divAsInt(x, 2) # change variable
       else:
         x = x*3 + 1 # change variable
       if x > max:
@@ -25,8 +23,8 @@ def main() -> None:
       p.append(x) # call procedure
       # draw what we have got so far, scaled to the canvas
       vg = list[VectorGraphic]() # variable definition
-      for i in range(0, len(p) - 1):
-        vg = (vg + [((LineVG()).withX1(scx(i, p)).withY1(scy(p[i], max)).withX2(scx(i + 1, p)).withY2(scy(p[i + 1], max)).withStrokeWidth(1))]) # change variable
+      for i in range(0, p.length() - 1):
+        vg = vg.withAppend((LineVG()).withX1(scx(i, p)).withY1(scy(p[i], max)).withX2(scx(i + 1, p)).withY2(scy(p[i + 1], max)).withStrokeWidth(1)) # change variable
       displayVectorGraphics(vg) # call procedure
       print(x)
       sleep_ms(100) # call procedure
@@ -35,7 +33,7 @@ def main() -> None:
 # scale x.  We pass in p just to get its length
 
 def scx(i: int, p: list[int]) -> float: # function
-  return ((i*100)/(len(p)))
+  return divAsFloat(i*100, p.length())
 
 # scale y
 
@@ -44,7 +42,7 @@ def scx(i: int, p: list[int]) -> float: # function
 # subtract 1 so that 1 is always at the same place on the canvas
 
 def scy(pi: int, max: int) -> float: # function
-  return 70 - (((pi - 1)*65)/((max - 1)))
+  return 70 - divAsFloat((pi - 1)*65, (max - 1))
 
 grey = 0x808080 # constant
 

--- a/test/files/date-time.py
+++ b/test/files/date-time.py
@@ -1,17 +1,11 @@
 # Python with Elan 2.0.0-alpha1
 
-import math
-
-import time
-def clock():
-  return int(time.time()*1000)
-
 def main() -> None:
   reply = "" # variable definition
-  while not reply.upper() == ("Q"):
+  while not reply.upperCase().equals("Q"):
     reply = input("RETURN for time now or Unix time (positive integer) or Q to quit") # change variable
-    if reply == (""):
-      now = math.floor((clock())/(1000)) # constant
+    if reply.equals(""):
+      now = divAsInt(clock(), 1000) # constant
       print(now)
       print(getDate(now))
     else:
@@ -23,12 +17,12 @@ def main() -> None:
 
 def getDate(unixSecs: int) -> str: # function
   dt = dateTime(unixSecs) # variable definition
-  hour = dt[0] # constant
-  minute = dt[1] # constant
-  second = dt[2] # constant
-  days = dt[3] # constant
-  year = dt[4] # constant
-  weekday = dt[5] # constant
+  hour = dt.item_0 # constant
+  minute = dt.item_1 # constant
+  second = dt.item_2 # constant
+  days = dt.item_3 # constant
+  year = dt.item_4 # constant
+  weekday = dt.item_5 # constant
   z2 = "00" # constant
   h = padLwithZero(hour) # constant
   m = padLwithZero(minute) # constant
@@ -36,8 +30,8 @@ def getDate(unixSecs: int) -> str: # function
   startDays = getStartDays() # variable definition
   startDaysL = startDaysList(year, startDays) # variable definition
   month_day = monthDay(startDaysL, (days % startDays[12])) # variable definition
-  month = month_day[0] # constant
-  day = month_day[1] # constant
+  month = month_day.item_0 # constant
+  day = month_day.item_1 # constant
   dayName = getWeekdayName(weekday) # constant
   d = padLwithZero(day) # constant
   monthName = getMonthName(month) # constant
@@ -48,12 +42,12 @@ def test_getDate(self) -> None:
 
 def dateTime(unixSecs: int) -> tuple[int, int, int, int, int, int]: # function
   # get separate values from Unix time
-  hour = (math.floor((math.floor((unixSecs)/(60)))/(60)) % 24) # constant
-  minute = math.floor((unixSecs)/(60)) % 60 # constant
+  hour = (divAsInt(divAsInt(unixSecs, 60), 60) % 24) # constant
+  minute = divAsInt(unixSecs, 60) % 60 # constant
   second = (unixSecs % 60) # constant
   # days and years from Unix epoch
-  unixDay = math.floor((unixSecs)/(daySecs)) # constant
-  years = math.floor(((unixDay + 1)/365.24)) # constant
+  unixDay = divAsInt(unixSecs, daySecs) # constant
+  years = ((unixDay + 1)/365.24).floor() # constant
   # this year and weekday
   year = unixYear + years # constant
   weekday = (unixDay + unixWeekday) % 7 # constant
@@ -83,7 +77,7 @@ def leap(year: int) -> bool: # function
   leapYear = False # variable definition
   if (year % 4) == 0:
     leapYear = True # change variable
-    if ((year % 100) == 0) and ((math.floor((year)/(100)) % 4) != 0):
+    if ((year % 100) == 0) and ((divAsInt(year, 100) % 4) != 0):
       leapYear = False # change variable
   return leapYear
 
@@ -144,7 +138,7 @@ def getStartDays() -> list[int]: # function
   return [1, 32, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335, 366]
 
 def padLwithZero(i: int) -> str: # function
-  return pad("L", "00", str(i))
+  return pad("L", "00", i.toString())
 
 def test_padLwithZero(self) -> None:
   self.assertEqual(padLwithZero(1), "01")
@@ -156,12 +150,12 @@ def pad(d: str, p: str, s: str) -> str: # function
   # p: output string pattern of pad characters and of length
   # s: input string
   sR = s # variable definition
-  if len(p) > len(s):
-    if d.upper() == ("L"):
+  if p.length() > s.length():
+    if d.upperCase().equals("L"):
       ps = p + s # constant
-      sR = ps[len(ps) - len(p):len(ps)] # change variable
-    elif d.upper() == ("R"):
-      sR = (s + p)[0:len(p)] # change variable
+      sR = ps.subString(ps.length() - p.length(), ps.length()) # change variable
+    elif d.upperCase().equals("R"):
+      sR = (s + p).subString(0, p.length()) # change variable
   return sR
 
 main()

--- a/test/files/in-place-ripple-sort.py
+++ b/test/files/in-place-ripple-sort.py
@@ -8,7 +8,7 @@ def main() -> None:
 
 def inPlaceRippleSort(li: list[int]) -> None: # procedure
   hasChanged = True # variable definition
-  lastComp = len(li) - 2 # variable definition
+  lastComp = li.length() - 2 # variable definition
   while hasChanged == True:
     hasChanged = False # change variable
     for i in range(0, lastComp + 1):

--- a/test/files/julia-set.py
+++ b/test/files/julia-set.py
@@ -29,11 +29,11 @@ def allpoints(p: Coords) -> list[VectorGraphic]: # function
   for xp in range(0, width + 1):
     for yp in range(0, height + 1):
       # scale and centre
-      n = onepoint(((((xp - width)/(2)))/(p.scale - p.xoff)), ((((yp - height)/(2)))/(p.scale - p.yoff)), nmax, p) # constant
+      n = onepoint(divAsFloat(divAsFloat(xp - width, 2), p.scale - p.xoff), divAsFloat(divAsFloat(yp - height, 2), p.scale - p.yoff), nmax, p) # constant
       # colour depends on how many iterations were done for that point
-      col = (0xffffff if n == nmax else ((n*0x010201) % 0xffffff)) # constant
-      rect = (RectangleVG()).withX(((xp)/(2))).withY(((yp)/(2))).withWidth(0.5).withHeight(0.5).withFillColour(col).withStrokeWidth(0.25) # variable definition
-      vg2 = (vg2 + [(rect)]) # change variable
+      col = if(n == nmax, 0xffffff, ((n*0x010201) % 0xffffff)) # constant
+      rect = (RectangleVG()).withX(divAsFloat(xp, 2)).withY(divAsFloat(yp, 2)).withWidth(0.5).withHeight(0.5).withFillColour(col).withStrokeWidth(0.25) # variable definition
+      vg2 = vg2.withAppend(rect) # change variable
   return vg2
 
 def onepoint(x: float, y: float, maxnum: int, p: Coords) -> int: # function
@@ -78,26 +78,26 @@ class Coords
     while not changed:
       k = getKey() # variable definition
       # loop because more than one key may have been pressed
-      while not k == (""):
-        if k == ("z"):
+      while not k.equals(""):
+        if k.equals("z"):
           self.scale = self.scale*1.2 # change variable
-        elif k == ("x"):
+        elif k.equals("x"):
           self.scale = self.scale/1.2 # change variable
-        elif k == ("ArrowUp"):
+        elif k.equals("ArrowUp"):
           self.yoff = self.yoff + panstep # change variable
-        elif k == ("ArrowDown"):
+        elif k.equals("ArrowDown"):
           self.yoff = self.yoff - panstep # change variable
-        elif k == ("ArrowLeft"):
+        elif k.equals("ArrowLeft"):
           self.xoff = self.xoff + panstep # change variable
-        elif k == ("ArrowRight"):
+        elif k.equals("ArrowRight"):
           self.xoff = self.xoff - panstep # change variable
-        elif k == ("g"):
+        elif k.equals("g"):
           self.jx = self.jx + jstep # change variable
-        elif k == ("j"):
+        elif k.equals("j"):
           self.jx = self.jx - jstep # change variable
-        elif k == ("y"):
+        elif k.equals("y"):
           self.jy = self.jy + jstep # change variable
-        elif k == ("h"):
+        elif k.equals("h"):
           self.jy = self.jy - jstep # change variable
           # for autocomplete in the RHS expression, don't type "property"
         else:

--- a/test/files/life.py
+++ b/test/files/life.py
@@ -22,27 +22,27 @@ def blackOrWhite(random: float) -> int: # function
   return result
 
 def north(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell[0] # constant
-  y = cell[1] # constant
-  y2 = (29 if y == 0 else y - 1) # constant
+  x = cell.item_0 # constant
+  y = cell.item_1 # constant
+  y2 = if(y == 0, 29, y - 1) # constant
   return (x, y2)
 
 def south(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell[0] # constant
-  y = cell[1] # constant
-  y2 = (0 if y == 29 else y + 1) # constant
+  x = cell.item_0 # constant
+  y = cell.item_1 # constant
+  y2 = if(y == 29, 0, y + 1) # constant
   return (x, y2)
 
 def east(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell[0] # constant
-  y = cell[1] # constant
-  x2 = (0 if x == 39 else x + 1) # constant
+  x = cell.item_0 # constant
+  y = cell.item_1 # constant
+  x2 = if(x == 39, 0, x + 1) # constant
   return (x2, y)
 
 def west(cell: tuple[int, int]) -> tuple[int, int]: # function
-  x = cell[0] # constant
-  y = cell[1] # constant
-  x2 = (39 if x == 0 else x - 1) # constant
+  x = cell.item_0 # constant
+  y = cell.item_1 # constant
+  x2 = if(x == 0, 39, x - 1) # constant
   return (x2, y)
 
 def northEast(cell: tuple[int, int]) -> tuple[int, int]: # function
@@ -64,8 +64,8 @@ def neighbourCells(x: int, y: int) -> list[tuple[int, int]]: # function
 def liveNeighbours(grid: list[list[int]], x: int, y: int) -> int: # function
   count = 0 # variable definition
   for cell in neighbourCells(x, y):
-    cx = cell[0] # constant
-    cy = cell[1] # constant
+    cx = cell.item_0 # constant
+    cy = cell.item_1 # constant
     if grid[cx][cy] == black:
       count = count + 1 # change variable
   return count

--- a/test/files/pathfinder.py
+++ b/test/files/pathfinder.py
@@ -1,8 +1,5 @@
 # Python with Elan 2.0.0-alpha1
 
-import enum
-import math
-
 def main() -> None:
   start = Point(5, 5) # variable definition
   destination = Point(34, 24) # variable definition
@@ -28,13 +25,13 @@ def runSolver(gr: list[list[int]], start: Point, destination: Point, rocks: list
     gr2 = addVisited(gr2, solver.getLastVisited()) # change variable
     displayBlocks(gr2) # call procedure
     sleep_ms(0) # call procedure
-  if solver.getLastVisited() == (destination):
+  if solver.getLastVisited().equals(destination):
     rl = solver.getRouteAndLength() # variable definition
-    route = rl[0] # variable definition
-    length = rl[1] # constant
+    route = rl.item_0 # variable definition
+    length = rl.item_1 # constant
     gr2 = addRoute(gr2, route) # change variable
     displayBlocks(gr2) # call procedure
-    printNoLine(f"Length of route: {round(length, 2)} ") # call procedure
+    printNoLine(f"Length of route: {length.round(2)} ") # call procedure
   else:
     printNoLine("No path found. ") # call procedure
 
@@ -42,11 +39,11 @@ def createRocksAndNodes(percentRocks: int, rocks: list[Point], nodes: list[Node]
   for x in range(0, 40):
     for y in range(1, 30):
       p = Point(x, y) # variable definition
-      if p == (start):
+      if p.equals(start):
         nodes.append(Node(p, 0, p.minDistTo(dest))) # call procedure
-      elif p == (dest):
+      elif p.equals(dest):
         nodes.append(Node(p, infinity, 0)) # call procedure
-      elif random() < ((percentRocks)/(100)):
+      elif random() < divAsFloat(percentRocks, 100):
         rocks.append(p) # call procedure
       else:
         nodes.append(Node(p, infinity, p.minDistTo(dest))) # call procedure
@@ -70,7 +67,7 @@ def addRoute(gr: list[list[int]], route: list[Point]) -> list[list[int]]: # func
   for p in route:
     graphics = withPut(graphics, p.x, p.y, orange) # change variable
   start = route[0] # variable definition
-  dest = route[len(route) - 1] # variable definition
+  dest = route[route.length() - 1] # variable definition
   graphics = withPut(graphics, start.x, start.y, green) # change variable
   graphics = withPut(graphics, dest.x, dest.y, red) # change variable
   return graphics
@@ -102,7 +99,7 @@ class Solver
   def visitNextPoint(self: Solver) -> None: # procedure
     self.updateNeighbours() # call procedure
     self.current = self.nextNodeToVisit() # change variable
-    if (self.current.isEmpty or (self.current.point == (self.destination))):
+    if (self.current.isEmpty or (self.current.point.equals(self.destination))):
       self.running = False # change variable
     else:
       current = self.current # variable definition
@@ -123,11 +120,11 @@ class Solver
       node = self.getNodeFor(p) # variable definition
       point = node.point # variable definition
       if not point.isEmpty:
-        neighbours = (neighbours + [(node)]) # change variable
+        neighbours = neighbours.withAppend(node) # change variable
     return neighbours
   def getNodeFor(self: Solver, p: Point) -> Node: # function
-    matches = self.nodes.filter(lambda n: Node => n.point == (p)) # variable definition
-    return (matches.head() if len(matches) == 1 else emptyNode())
+    matches = self.nodes.filter(lambda n: Node => n.point.equals(p)) # variable definition
+    return if(matches.length() == 1, matches.head(), emptyNode())
   def getLastVisited(self: Solver) -> Point: # function
     return self.current.point
   def nextNodeToVisit(self: Solver) -> Node: # function
@@ -155,7 +152,7 @@ class Solver
     route = [self.destination] # variable definition
     length = 0.0 # variable definition
     node = self.getNodeFor(self.destination) # variable definition
-    while not node.point == (self.start):
+    while not node.point.equals(self.start):
       previous = node.via # variable definition
       p = node.point # variable definition
       length = length + p.minDistTo(previous) # change variable
@@ -190,7 +187,7 @@ class Node
   def setVia(self: Node, p: Point) -> None: # procedure
     self.via = p # change variable
   def toString(self: Node) -> str: # function
-    return f"[{str(self.point)} {self.visited} {self.distFromStart}]"
+    return f"[{self.point.toString()} {self.visited} {self.distFromStart}]"
 
 
 def emptyPoint() -> Point: # function
@@ -208,9 +205,9 @@ class Point
       self.x = x # change variable
       self.y = y # change variable
   def minDistTo(self: Point, p: Point) -> float: # function
-    return math.sqrt(pow((p.x - self.x), 2) + pow((p.y - self.y), 2))
+    return sqrt(pow((p.x - self.x), 2) + pow((p.y - self.y), 2))
   def isAdjacentTo(self: Point, p: Point) -> bool: # function
-    return (self.minDistTo(p) == 1) or (round(self.minDistTo(p), 4) == round(math.sqrt(2), 4))
+    return (self.minDistTo(p) == 1) or (self.minDistTo(p).round(4) == sqrt(2).round(4))
   # Returns the 8 theoretically-neighbouring points, whether or not within bounds
   def neighbouringPoints(self: Point) -> list[Point]: # function
     return [Point(self.x - 1, self.y - 1), Point(self.x, self.y - 1), Point(self.x + 1, self.y - 1), Point(self.x - 1, self.y), Point(self.x + 1, self.y), Point(self.x - 1, self.y + 1), Point(self.x, self.y + 1), Point(self.x + 1, self.y + 1)]

--- a/test/files/roman-numerals-turing-machine.py
+++ b/test/files/roman-numerals-turing-machine.py
@@ -1,7 +1,5 @@
 # Python with Elan 2.0.0-alpha1
 
-import enum
-
 # Turing Machine that converts a Year from decimal to roman numerals
 
 # Run the program, enter the number to convert and watch the machine in action.
@@ -16,7 +14,7 @@ def main() -> None:
   tm = TuringMachine(initState, haltState) # variable definition
   addRulesForRomanNumeralsInto(tm) # call procedure
   dec = inputIntBetween("Enter a year:", 1, 3999) # constant
-  tm.setTape(str(dec)) # call procedure
+  tm.setTape(dec.toString()) # call procedure
   steps = 0 # variable definition
   while not tm.isHalted():
     rule = tm.findMatchingRule() # variable definition
@@ -27,9 +25,9 @@ def main() -> None:
     printTab(tm.headPosition - 1, "^") # call procedure
     print(f"Step: {steps}")
     print(f"State: {tm.currentState}")
-    print(f"Rule applied: {str(rule)}")
+    print(f"Rule applied: {rule.toString()}")
     sleep_ms(40) # call procedure
-  print(f"The roman numeral equivalent for {dec} is {tm.tape.strip()}")
+  print(f"The roman numeral equivalent for {dec} is {tm.tape.trim()}")
 
 initState = "init" # constant
 
@@ -55,26 +53,26 @@ class TuringMachine
   def setTape(self: TuringMachine, tape: str) -> None: # procedure
     self.tape = tape # change variable
   def append(self: TuringMachine, rule: Rule) -> None: # procedure
-    self.rules = (self.rules + [(rule)]) # change variable
+    self.rules = self.rules.withAppend(rule) # change variable
   def singleStep(self: TuringMachine) -> None: # procedure
     rule = self.findMatchingRule() # variable definition
     self.execute(rule) # call procedure
   def isHalted(self: TuringMachine) -> bool: # function
-    return self.currentState == (self.haltState)
+    return self.currentState.equals(self.haltState)
   def findMatchingRule(self: TuringMachine) -> Rule: # function
-    matches = self.rules.filter(lambda r: Rule => (r.currentState == (self.currentState)) and (r.currentSymbol == (self.tape[self.headPosition]))) # variable definition
-    if len(matches) == 0:
+    matches = self.rules.filter(lambda r: Rule => (r.currentState.equals(self.currentState)) and (r.currentSymbol.equals(self.tape[self.headPosition]))) # variable definition
+    if matches.length() == 0:
       raise ElanRuntimeError("f"No rule matching state {self.currentState} and symbol {self.tape[self.headPosition]}"")
     return matches.head()
   def write(self: TuringMachine, newSymbol: str) -> None: # procedure
     hp = self.headPosition # constant
-    self.tape = self.tape[0:hp] + newSymbol + self.tape[hp + 1:len(self.tape)] # change variable
+    self.tape = self.tape.subString(0, hp) + newSymbol + self.tape.subString(hp + 1, self.tape.length()) # change variable
   def execute(self: TuringMachine, rule: Rule) -> None: # procedure
     self.currentState = rule.nextState # change variable
     self.write(rule.writeSymbol) # call procedure
     if rule.move == Dir.right:
       self.headPosition = self.headPosition + 1 # change variable
-      if self.headPosition >= len(self.tape):
+      if self.headPosition >= self.tape.length():
         self.tape = self.tape + " " # change variable
     else:
       self.headPosition = self.headPosition - 1 # change variable

--- a/test/files/snake-OOP.py
+++ b/test/files/snake-OOP.py
@@ -1,7 +1,5 @@
 # Python with Elan 2.0.0-alpha1
 
-import enum
-
 # Use the W,A,S,D keys to change Snake direction
 
 def main() -> None:
@@ -37,32 +35,32 @@ class Snake
     body = self.body # variable definition
     body.append(self.head) # call procedure
     self.head = self.head.getAdjacentSquare(self.currentDir) # change variable
-    if self.head == (apple.location):
+    if self.head.equals(apple.location):
       apple.newRandomPosition(self) # call procedure
     else:
-      self.body = self.body.subList(1, len(self.body)) # change variable
+      self.body = self.body.subList(1, self.body.length()) # change variable
   def updateBlocks(self: Snake, blocks: list[list[int]]) -> None: # procedure
     blocks[self.head.x][self.head.y] = green # change variable
-    if not self.body[0] == (self.priorTail):
+    if not self.body[0].equals(self.priorTail):
       blocks[self.priorTail.x][self.priorTail.y] = white # change variable
   def score(self: Snake) -> int: # function
-    return len(self.body) - 1
+    return self.body.length() - 1
   def bodyCovers(self: Snake, sq: Square) -> bool: # function
     result = False # variable definition
     for seg in self.body:
-      if (seg == (sq)):
+      if (seg.equals(sq)):
         result = True # change variable
     return result
   def gameOver(self: Snake) -> bool: # function
     return self.bodyCovers(self.head) or self.head.hasHitEdge()
   def setDirection(self: Snake, key: str) -> None: # private procedure
-    if key == ("w"):
+    if key.equals("w"):
       self.currentDir = Direction.up # change variable
-    elif key == ("s"):
+    elif key.equals("s"):
       self.currentDir = Direction.down # change variable
-    elif key == ("a"):
+    elif key.equals("a"):
       self.currentDir = Direction.left # change variable
-    elif key == ("d"):
+    elif key.equals("d"):
       self.currentDir = Direction.right # change variable
 
 

--- a/test/files/snake-fp.py
+++ b/test/files/snake-fp.py
@@ -15,39 +15,39 @@ def main() -> None:
   print(f"Game Over! Score: {score(game)}")
 
 def clockTick(g: Game, k: str) -> Game: # function
-  g2 = (g if k == ("") else g.withKey(k)) # variable definition
+  g2 = if(k.equals(""), g, g.withKey(k)) # variable definition
   g3 = moveSnake(g2) # variable definition
   g4 = eatAppleIfPoss(g3) # variable definition
-  return (g4.withIsOn(False) if gameOver(g4) else g4)
+  return if(gameOver(g4), g4.withIsOn(False), g4)
 
 def updateGraphics(g: Game, b: list[list[int]]) -> list[list[int]]: # function
   b2 = graphicsPut(b, g.apple.x, g.apple.y, red) # variable definition
   b3 = graphicsPut(b2, g.head.x, g.head.y, green) # variable definition
   tail = g.body[0] # variable definition
-  tailColour = (green if tail == (g.priorTail) else white) # variable definition
+  tailColour = if(tail.equals(g.priorTail), green, white) # variable definition
   return graphicsPut(b3, tail.x, tail.y, tailColour)
 
 def graphicsPut(graphics: list[list[int]], x: int, y: int, colour: int) -> list[list[int]]: # function
   return graphics.withSet(x, graphics[x].withSet(y, colour))
 
 def score(g: Game) -> int: # function
-  return len(g.body) - 2
+  return g.body.length() - 2
 
 def moveSnake(g: Game) -> Game: # function
   k = g.key # variable definition
   x = g.head.x # variable definition
   y = g.head.y # variable definition
-  newX = (x - 1 if k == ("a") else (x + 1 if k == ("d") else x)) # variable definition
-  newY = (y - 1 if k == ("w") else (y + 1 if k == ("s") else y)) # variable definition
-  return g.withBody((g.body + [(g.head)])).withHead(Square(newX, newY))
+  newX = if(k.equals("a"), x - 1, if(k.equals("d"), x + 1, x)) # variable definition
+  newY = if(k.equals("w"), y - 1, if(k.equals("s"), y + 1, y)) # variable definition
+  return g.withBody(g.body.withAppend(g.head)).withHead(Square(newX, newY))
 
 def eatAppleIfPoss(g: Game) -> Game: # function
   tail = g.body[0] # variable definition
-  moveTail = g.body.subList(1, len(g.body)) # variable definition
-  return (g.withNewApple() if headOverApple(g) else g.withPriorTail(tail).withBody(moveTail))
+  moveTail = g.body.subList(1, g.body.length()) # variable definition
+  return if(headOverApple(g), g.withNewApple(), g.withPriorTail(tail).withBody(moveTail))
 
 def headOverApple(g: Game) -> bool: # function
-  return g.head == (g.apple)
+  return g.head.equals(g.apple)
 
 def gameOver(g: Game) -> bool: # function
   return g.body.contains(g.head) or hasHitEdge(g)
@@ -78,14 +78,14 @@ class Game
     return ""
   def withNewApple(self: Game) -> Game: # function
     x_rnd2 = self.rnd.nextInt(0, 39) # variable definition
-    x = x_rnd2[0] # variable definition
-    rnd2 = x_rnd2[1] # variable definition
+    x = x_rnd2.item_0 # variable definition
+    rnd2 = x_rnd2.item_1 # variable definition
     y_rnd3 = rnd2.nextInt(0, 29) # variable definition
-    y = y_rnd3[0] # variable definition
-    rnd3 = y_rnd3[1] # variable definition
+    y = y_rnd3.item_0 # variable definition
+    rnd3 = y_rnd3.item_1 # variable definition
     apple2 = Square(x, y) # variable definition
     g2 = self.withApple(apple2).withRnd(rnd3) # variable definition
-    return (g2.withNewApple() if g2.body.contains(apple2) else g2)
+    return if(g2.body.contains(apple2), g2.withNewApple(), g2)
   def withHead(self: Game, value: Square) -> Game: # function
     copyOfThis = copy(self) # variable definition
     copyOfThis.head = value # change variable
@@ -256,7 +256,7 @@ def test_newSquare(self) -> None:
 def test_newGame(self) -> None:
   rnd = Random() # variable definition
   game = Game(rnd) # variable definition
-  totest = game.rnd == (rnd) # variable definition
+  totest = game.rnd.equals(rnd) # variable definition
   self.assertEqual(totest, True)
   self.assertEqual(game.head, Square(22, 15))
   body = game.body # variable definition


### PR DESCRIPTION
We have changed our minds about translating expressions at all for export. For now exported Python files will have the same text as appears on the screen.

Disabled in `src/ide/frames/language-python.ts` with minimum change. Test files (`test/files/*.py`) adjusted back.

I'm going to have some lunch while the tests run, and merge it into main later.
