### PR TITLE
Invalid literal reg exp locks up IDE #2931

### DIFF
--- a/src/compiler/compile-rules.ts
+++ b/src/compiler/compile-rules.ts
@@ -1274,6 +1274,14 @@ export function mustNotBeTwoUnaryExpressions(compileErrors: CompileError[], loca
   compileErrors.push(new SyntaxCompileError("Unsupported operation.", location));
 }
 
+export function mustBeValidRegExp(
+  message: string,
+  compileErrors: CompileError[],
+  location: string,
+) {
+  compileErrors.push(new SyntaxCompileError(message, location, "LibRef.html#RegExpFunctions"));
+}
+
 const compilerAssertions = true;
 
 export function compilerAssert(condition: boolean, message: string) {

--- a/src/compiler/syntax-nodes/literal-regex-asn.ts
+++ b/src/compiler/syntax-nodes/literal-regex-asn.ts
@@ -1,21 +1,48 @@
 import { AstNode } from "../../compiler/compiler-interfaces/ast-node";
 import { RegExpType } from "../../compiler/symbols/regexp-type";
+import { Scope } from "../compiler-interfaces/scope";
+import { getGlobalScope } from "../symbols/symbol-helpers";
+import { mustBeValidRegExp } from "../compile-rules";
 import { AbstractAstNode } from "./abstract-ast-node";
+
+// "new RegExp(r)" throws a SyntaxError at run time
+// if the string "r" is ill-formed, eg contains an unclosed square or round bracket,
+// or ends in a backslash or contains "(?" followed by an invalid option.
+// The error message varies depending on what is wrong.
+// We allow that at parse time, by catching and noting the error,
+// as the user is typically still typing her regexp,
+// and we translate it into a compile error at compile time.
 
 export class LiteralRegExAsn extends AbstractAstNode implements AstNode {
   constructor(
     rawValue: string,
     public readonly fieldId: string,
+    private readonly scope: Scope,
   ) {
     super();
     const trimmed = rawValue.trim();
     const r = trimmed.substring(1, trimmed.length - 1); //Remove delimiting slashes as RegExp will add them back automatically
-    this.value = new RegExp(r);
+    try {
+      this.value = new RegExp(r);
+      this.valueValid = true;
+      this.valueMessage = "OK"; // to keep TypeScript happy
+    } catch (e) {
+      this.value = /invalid/;
+      this.valueValid = false;
+      this.valueMessage = (e as Error).message;
+    }
   }
 
   value: RegExp;
+  private valueValid: boolean;
+  private valueMessage: string;
 
   compile(): string {
+    this.compileErrors = [];
+    if (!this.valueValid) {
+      mustBeValidRegExp(this.valueMessage, this.compileErrors, this.fieldId);
+    }
+    getGlobalScope(this.scope).addCompileErrors(this.compileErrors);
     return `${this.value}`;
   }
 

--- a/src/ide/compile-api/ast-visitor.ts
+++ b/src/ide/compile-api/ast-visitor.ts
@@ -699,7 +699,7 @@ export function transform(
   }
 
   if (node instanceof LitRegExp) {
-    return new LiteralRegExAsn(node.matchedText, fieldId);
+    return new LiteralRegExAsn(node.matchedText, fieldId, scope);
   }
 
   if (node instanceof IdentifierDef) {

--- a/test/compiler/regEx.test.ts
+++ b/test/compiler/regEx.test.ts
@@ -222,4 +222,28 @@ end main`;
       "Argument types. Expected: regExp (RegExp), Provided: String.LangRef.html#compile_error",
     ]);
   });
+
+  test("Fail_IllFormedRegex", async () => {
+    const code = `${testHeader}
+
+main
+  variable r set to /[/
+end main`;
+
+    const fileImpl = new FileImpl(
+      testHash,
+      new Profile(""),
+      "",
+      transforms(),
+      new StdLib(new StubInputOutput()),
+      false,
+      true,
+    );
+    await fileImpl.parseFrom(new CodeSourceFromString(code));
+
+    assertParses(fileImpl);
+    assertDoesNotCompile(fileImpl, [
+      "Invalid regular expression: /[/: Unterminated character classLibRef.html#RegExpFunctions",
+    ]);
+  });
 });


### PR DESCRIPTION
If the user types an invalid literal regular expression eg `/[/` JavaScript throws a SyntaxError at run time which is reported as an Elan internal error.

My preferred fix is to catch and record the error message but otherwise let the parsing run on while the regular expression is being typed, and report the error at compile time.

Includes a new test for this in regEx.test.ts.