### PR TITLE
Profile menu, demo filtering, URL parameters #2926 #2942

### DIFF
--- a/src/ide/frames/file-impl.ts
+++ b/src/ide/frames/file-impl.ts
@@ -117,7 +117,7 @@ export class FileImpl implements File {
 
   constructor(
     private readonly hash: (toHash: string) => Promise<string>,
-    public readonly profile: Profile,
+    public profile: Profile,
     private userName: string | undefined,
     private readonly transform: Transforms,
     stdLib: StdLib,
@@ -173,6 +173,10 @@ export class FileImpl implements File {
 
   getProfile(): Profile {
     return this.profile;
+  }
+
+  setProfile(p: Profile) {
+    this.profile = p;
   }
 
   getChildren(): Frame[] {

--- a/src/ide/frames/frame-interfaces/file.ts
+++ b/src/ide/frames/frame-interfaces/file.ts
@@ -46,6 +46,7 @@ export interface File extends Parent {
   getNextId(): number;
   getFactory(): StatementFactory;
   getProfile(): Profile;
+  setProfile(p: Profile): void;
 
   indent(): string;
   expandCollapseAll(): void;

--- a/src/ide/styles/ide.css
+++ b/src/ide/styles/ide.css
@@ -662,3 +662,12 @@ a.menu-item:hover:visited
   margin-left: 1.12em;
   display: block;
 }
+
+/* Make the demos in the menu appear or disappear depending on the profile */
+/* First hide anything with a profile */
+div.demo-file.procedural, div.demo-file.oop, div.demo-file.functional { display: none; }
+/* And then make them reappear if their profile(s) matches our current profile */
+body.procedural div.demo-file.procedural { display: revert; }
+body.oop div.demo-file.oop { display: revert; }
+body.functional div.demo-file.functional { display: revert; }
+

--- a/src/ide/web-content/index.html
+++ b/src/ide/web-content/index.html
@@ -9,7 +9,7 @@
         <link href="favicon.ico" rel="icon" />
         <title>Elan</title>
     </head>
-    <body class="procedural">
+    <body>
         <a href="documentation/index.html" style="display:none">Documentation</a> <!-- Direct link for search engines -->
         <div id="lhs">
             <div id="code-controls">
@@ -27,9 +27,9 @@
                         <div class="demo-file menu-item" tabindex="-1" id="demo/maze-generator.elan">Maze generator</div>
                         <div class="demo-file menu-item" tabindex="-1" id="demo/pathfinder.elan">Pathfinder</div>
                         <div class="demo-file menu-item" tabindex="-1" id="demo/roman-numerals-turing-machine.elan">Roman Numerals Turing Machine</div>
-                        <div class="demo-file menu-item" tabindex="-1" id="demo/snake_PP.elan">Snake</div>
-                        <div class="demo-file menu-item" tabindex="-1" id="demo/snake_OOP.elan">Snake - object-oriented</div>
-                        <div class="demo-file menu-item" tabindex="-1" id="demo/snake_FP.elan">Snake - functional</div>
+                        <div class="demo-file menu-item procedural" tabindex="-1" id="demo/snake_PP.elan">Snake</div>
+                        <div class="demo-file menu-item oop" tabindex="-1" id="demo/snake_OOP.elan">Snake - object-oriented</div>
+                        <div class="demo-file menu-item functional" tabindex="-1" id="demo/snake_FP.elan">Snake - functional</div>
                         <div class="demo-file menu-item" tabindex="-1" id="demo/turtle-spiral.elan">Turtle Spiral</div>
                         <div class="demo-file menu-item" tabindex="-1" id="demo/turtle-snowflake.elan">Turtle Snowflake</div>
                         <div class="demo-file menu-item" tabindex="-1" id="demo/turtle_dragon.elan">Turtle Dragon</div>
@@ -68,6 +68,15 @@
                     </div>
                 </div>
 
+                <div class="dropdown">
+                    <button id="profile" class="plain" tabindex="0" aria-haspopup="true" aria-expanded="false" aria-controls="profile-menu"></button>
+                    <div id="profile-menu" class="dropdown-content" hidden>
+                        <div class="plain menu-item" tabindex="-1" id="profile-procedural">Procedural</div>
+                        <div class="plain menu-item" tabindex="-1" id="profile-oop">Object Oriented</div>
+                        <div class="plain menu-item" tabindex="-1" id="profile-functional">Functional</div>
+                    </div>
+                </div>
+
                 <dialog id="preferences-dialog">
                     <form>
                         <div>
@@ -75,7 +84,7 @@
                             <input type="checkbox" id="use-cvd" name="cvd" value="use-cvd">
                         </div>
                         <div>
-                            <button id="confirmBtn">confirm</button>
+                            <button id="confirmBtn" type="button">confirm</button>
                         </div>
                     </form>
                 </dialog>

--- a/src/ide/web/code-editor-view-model.ts
+++ b/src/ide/web/code-editor-view-model.ts
@@ -42,6 +42,7 @@ system.stdlib = stdlib; // to allow injection
 export class CodeEditorViewModel implements ICodeEditorViewModel {
   private file?: File = undefined;
   private profile?: Profile = undefined;
+  private cvdCss?: string = undefined;
 
   lastDOMEvent: Event | undefined;
   lastEditorEvent: editorEvent | undefined;
@@ -61,6 +62,19 @@ export class CodeEditorViewModel implements ICodeEditorViewModel {
 
   setProfile(p: Profile) {
     this.profile = p;
+    this.file?.setProfile(p);
+  }
+
+  getProfile() {
+    return this.profile;
+  }
+
+  setCss(stylesheet: string): void {
+    this.cvdCss = stylesheet;
+  }
+
+  getCss() {
+    return this.cvdCss;
   }
 
   set fileName(fn: string) {

--- a/src/ide/web/web-scripts.ts
+++ b/src/ide/web/web-scripts.ts
@@ -65,6 +65,10 @@ const vbButton = document.getElementById("vb-language") as HTMLDivElement;
 const csButton = document.getElementById("cs-language") as HTMLDivElement;
 const javaButton = document.getElementById("java-language") as HTMLDivElement;
 const elanButton = document.getElementById("elan-language") as HTMLDivElement;
+const profileMenu = document.getElementById("profile-menu") as HTMLDivElement;
+const proceduralButton = document.getElementById("profile-procedural") as HTMLDivElement;
+const oopButton = document.getElementById("profile-oop") as HTMLDivElement;
+const functionalButton = document.getElementById("profile-functional") as HTMLDivElement;
 
 const trimButton = document.getElementById("trim") as HTMLButtonElement;
 const loadButton = document.getElementById("load") as HTMLDivElement;
@@ -76,6 +80,7 @@ const undoButton = document.getElementById("undo") as HTMLButtonElement;
 const redoButton = document.getElementById("redo") as HTMLButtonElement;
 const fileButton = document.getElementById("file") as HTMLButtonElement;
 const languageButton = document.getElementById("language") as HTMLButtonElement;
+const profileButton = document.getElementById("profile") as HTMLButtonElement;
 const saveAsStandaloneButton = document.getElementById("save-as-standalone") as HTMLDivElement;
 const preferencesButton = document.getElementById("preferences") as HTMLDivElement;
 const copyAsUrlButton = document.getElementById("copy-as-url") as HTMLDivElement;
@@ -122,6 +127,8 @@ const worksheetTab = document.getElementById("worksheet-tab");
 const dialog = document.getElementById("preferences-dialog") as HTMLDialogElement;
 const closePreferencesDialogButton = document.getElementById("confirmBtn");
 const useCvdTickbox = document.getElementById("use-cvd") as HTMLInputElement;
+
+const docBody = document.getElementsByTagName("body")[0] as HTMLBodyElement;
 
 const elanInputOutput = new WebInputOutput();
 
@@ -245,6 +252,7 @@ class IDEViewModel implements IIDEViewModel {
           clearDisplayButton,
           fileButton,
           languageButton,
+          profileButton,
           loadButton,
           saveAsStandaloneButton,
           preferencesButton,
@@ -261,6 +269,7 @@ class IDEViewModel implements IIDEViewModel {
 
       this.enable(fileButton, "File actions");
       this.enable(languageButton, "Language");
+      this.enable(profileButton, "Profile");
       this.enable(loadButton, "Load code from a file");
       this.enable(appendButton, "Append code from a file onto the end of the existing code");
       this.enable(newButton, "Clear the current code and start afresh");
@@ -836,6 +845,19 @@ elanButton?.addEventListener("click", async (_event: Event) => {
   await codeViewModel.changeLanguage(LanguageElan.Instance, ideViewModel, testRunner, false);
 });
 
+async function profileEventHandler(this: HTMLDivElement, _event: MouseEvent) {
+  const oldProfileName = codeViewModel.getProfile()?.name || "";
+  const profileName = this.id.replace("profile-", "");
+  await codeViewModel.setProfile(new Profile(profileName));
+  profileButton.textContent = this.textContent;
+  const bodyClassList = docBody.classList;
+  bodyClassList.remove(oldProfileName);
+  bodyClassList.add(profileName);
+}
+proceduralButton?.addEventListener("click", profileEventHandler);
+oopButton?.addEventListener("click", profileEventHandler);
+functionalButton?.addEventListener("click", profileEventHandler);
+
 loadButton.addEventListener("click", chooser(getUploader(), false));
 
 appendButton.addEventListener("click", chooser(getAppender(), true));
@@ -854,6 +876,26 @@ copyAsUrlButton.addEventListener("click", async (_e: Event) => {
   const code = await codeViewModel.renderAsSource();
   const bEncoded = btoa(code);
   const url = new URL(window.location.href);
+
+  const urlParams: { [propName: string]: { default: string; current: string } } = {
+    profile: { default: "procedural", current: codeViewModel.getProfile()?.name || "procedural" },
+    lang: { default: "elan", current: codeViewModel.getLanguage().languageHtmlClass },
+    cvd: { default: "colourScheme", current: codeViewModel.getCss() ?? "colourScheme" },
+  };
+
+  for (const p in urlParams) {
+    const e = urlParams[p];
+    if (e.default === e.current) {
+      // The url was derived from window.location.href
+      // so it may already have params which we don't want,
+      // if a setting has been changed to the default
+      // since the page was loaded.
+      url.searchParams.delete(p);
+    } else {
+      url.searchParams.set(p, e.current);
+    }
+  }
+
   url.searchParams.set("code", bEncoded);
   const urlAsString = url.toString();
 
@@ -883,6 +925,8 @@ for (const elem of demoFiles) {
 
 preferencesButton.addEventListener("click", (event: Event) => {
   if (!isDisabled(event)) {
+    // in case it was set via the cvd parameter in the URL when the page was loaded
+    useCvdTickbox.checked = codeViewModel.getCss() === "cvd-colourScheme";
     // otherwise it can pick up click and close immediately
     setTimeout(() => dialog.showModal(), 1);
   }
@@ -890,7 +934,9 @@ preferencesButton.addEventListener("click", (event: Event) => {
 
 closePreferencesDialogButton?.addEventListener("click", (event: Event) => {
   if (!isDisabled(event)) {
-    changeCss(useCvdTickbox.checked ? "cvd-colourScheme" : "colourScheme");
+    const newCss = useCvdTickbox.checked ? "cvd-colourScheme" : "colourScheme";
+    changeCss(newCss);
+    codeViewModel.setCss(newCss);
     dialog.close();
   }
 });
@@ -970,11 +1016,13 @@ demosButton.addEventListener("click", handleClickDropDownButton);
 fileButton.addEventListener("click", handleClickDropDownButton);
 standardWorksheetButton.addEventListener("click", handleClickDropDownButton);
 languageButton.addEventListener("click", handleClickDropDownButton);
+profileButton.addEventListener("click", handleClickDropDownButton);
 
 demosButton.addEventListener("keydown", handleKeyDropDownButton);
 fileButton.addEventListener("keydown", handleKeyDropDownButton);
 standardWorksheetButton.addEventListener("keydown", handleKeyDropDownButton);
 languageButton.addEventListener("keydown", handleKeyDropDownButton);
+profileButton.addEventListener("keydown", handleKeyDropDownButton);
 
 demosMenu.addEventListener("keydown", (e) =>
   handleMenuKey(e, codeViewModel, ideViewModel, testRunner),
@@ -988,11 +1036,15 @@ worksheetMenu.addEventListener("keydown", (e) =>
 languageMenu.addEventListener("keydown", (e) =>
   handleMenuKey(e, codeViewModel, ideViewModel, testRunner),
 );
+profileMenu.addEventListener("keydown", (e) =>
+  handleMenuKey(e, codeViewModel, ideViewModel, testRunner),
+);
 
 demosMenu.addEventListener("click", () => collapseMenu(demosButton, false));
 fileMenu.addEventListener("click", () => collapseMenu(fileButton, false));
 worksheetMenu.addEventListener("click", () => collapseMenu(standardWorksheetButton, false));
 languageMenu.addEventListener("click", () => collapseMenu(languageButton, false));
+profileMenu.addEventListener("click", () => collapseMenu(profileButton, false));
 
 displayTab?.addEventListener("click", () => tabViewModel.showDisplayTab());
 infoTab?.addEventListener("click", () => tabViewModel.showInfoTab());
@@ -1012,7 +1064,7 @@ window.addEventListener("message", async (m) => {
 
 if (checkIsChrome() || confirmContinueOnNonChromeBrowser()) {
   const sp = new URL(window.location.href).searchParams;
-  const param = sp.get("profile") || "";
+  const param = sp.get("profile") || "procedural";
   const profile = new Profile(param);
   setup(profile);
 } else {
@@ -1055,7 +1107,14 @@ async function setup(p: Profile) {
 
   if (cvd) {
     changeCss("cvd-colourScheme");
+    codeViewModel.setCss("cvd-colourScheme");
   }
+
+  // add "procedural", "oop" or "functional" to body
+  // to control which demos are visible
+  docBody.classList.add(p.name);
+  // and set the text on the button to match
+  profileButton.textContent = document.getElementById("profile-" + p.name)!.textContent;
 
   if (code) {
     await codeViewModel.loadFromUrl(ideViewModel, fileManager, testRunner, code);

--- a/src/ide/web/web-scripts.ts
+++ b/src/ide/web/web-scripts.ts
@@ -846,13 +846,18 @@ elanButton?.addEventListener("click", async (_event: Event) => {
 });
 
 async function profileEventHandler(this: HTMLDivElement, _event: MouseEvent) {
-  const oldProfileName = codeViewModel.getProfile()?.name || "";
-  const profileName = this.id.replace("profile-", "");
-  await codeViewModel.setProfile(new Profile(profileName));
-  profileButton.textContent = this.textContent;
-  const bodyClassList = docBody.classList;
-  bodyClassList.remove(oldProfileName);
-  bodyClassList.add(profileName);
+  // Changing the profile clears the current code
+  if (checkForUnsavedChanges(fileManager, codeViewModel, cancelMsg)) {
+    const oldProfileName = codeViewModel.getProfile()?.name || "";
+    const profileName = this.id.replace("profile-", "");
+    await codeViewModel.setProfile(new Profile(profileName));
+    codeViewModel.recreateFile(ideViewModel, true);
+    await codeViewModel.initialDisplay(fileManager, ideViewModel, testRunner, false);
+    profileButton.textContent = this.textContent;
+    const bodyClassList = docBody.classList;
+    bodyClassList.remove(oldProfileName);
+    bodyClassList.add(profileName);
+  }
 }
 proceduralButton?.addEventListener("click", profileEventHandler);
 oopButton?.addEventListener("click", profileEventHandler);


### PR DESCRIPTION
[Richard -- I'm happy for you to merge this to main.  I just thought you should check it first in case of major misunderstanding or something I missed]

Filter demos displayed based on paradigm #2926

Make appropriately marked up demos appear and disappear in the list according to the profile selected.

Ability to change the profile via the UI #2942

Most of the changes are in `src/ide/web/web-scripts.ts`.

Set the class on the body HTML element to "procedural", "oop" or "functional" from a new Profile menu. I took off the default "procedural" in index.html to avoid having to remove it specially if loading from a URL with a profile parameter.  Instead, the code always sets the current profile name as the class.

Also save and restore the profile setting, CVD stylesheet setting and language via the "copy Url for this code" operation. Users can also contruct suitable URLs by hand.

Add the ability to change the profile stored in an existing file (FileImpl) object.

In `src/ide/web/code-editor-view-model.ts` add the ability to store and read back the cvd stylesheet setting, and to read back the current profile setting, for "copy Url for this code" and to be able to remove the current profile setting from the body tag when it changes.

To avoid hard-coding too much text in the code, the menu button text is taken from the HTML of the menu item selected. This could be changed to use an attribute if different text were needed.

I notice the need to cancel the "Leave site" dialogue when changing the CVD setting. This is easily fixed by adding `type="button"` to the button, so I have done that as I was changing index.html anyway.
See "CVD preference change #2317", which also includes other enhancements for another time.