### PR TITLE
Cursor jumps back when editing expression ending in close-bracket #2983

### DIFF
--- a/src/ide/frames/fields/arg-list-field.ts
+++ b/src/ide/frames/fields/arg-list-field.ts
@@ -91,8 +91,16 @@ export class ArgListField extends AbstractField {
   override parseCurrentText(): void {
     super.parseCurrentText();
     if (this.readParseStatus() === ParseStatus.invalid && this.text.endsWith(")")) {
+      const oldText = this.text;
       this.text = this.text.slice(0, this.text.length - 1);
       super.parseCurrentText();
+      if (this.readParseStatus() !== ParseStatus.valid) {
+        // Keep the change if the parse status is now "valid".
+        // It may be "invalid" or "incomplete" now.
+        // Put the bracket back if removing it didn't help, as it spoils the cursor positioning
+        // when editing in the middle of a field that ends in ")".
+        this.text = oldText;
+      }
     }
   }
 }


### PR DESCRIPTION
- Enter: `call print(atan(4))`
- Click on (or tab to) the expression again.
- Position the cursor just after the `4`.
- Type `+`

One of the trailing brackets disappears, and the cursor jumps back one character to before the "+". Easy to fix in `src/ide/frames/fields/arg-list-field.ts` by putting the bracket back if removing it doesn't cause the expression to parse as valid. It still ignores extra "`)`" typed at the end as intended. Issue #1110 involved a change in this area.