### PR TITLE
Make the text output window scroll when new output is printed #1458

### DIFF
--- a/src/ide/web/web-input-output.ts
+++ b/src/ide/web/web-input-output.ts
@@ -318,6 +318,7 @@ export class WebInputOutput implements ElanInputOutput {
   async renderPrintedText(): Promise<void> {
     const div = document.getElementById("printed-text")!;
     div.innerHTML = this.printedText;
+    div.scrollIntoView(false);
     return Promise.resolve();
   }
 


### PR DESCRIPTION
Add `scrollIntoView(false)` in `renderPrintedText` so that the bottom of the display "printed-text" div lines up with the bottom of the container.