### PR TITLE
Can't select fields after undo in non-Elan language #3161

### DIFF
--- a/src/ide/frames/file-impl.ts
+++ b/src/ide/frames/file-impl.ts
@@ -695,9 +695,11 @@ export class FileImpl implements File {
         source.removeRegEx(Regexes.newLine, false);
         source.removeRegEx(Regexes.newLine, false);
       }
+      this.setLanguageFromHeader(language); // string
+      const savedLanguage = this._language; // Instance
       this._language = LanguageElan.Instance;
       this.parseBodyFrom(source);
-      this.setLanguageFromHeader(language);
+      this.setLanguage(savedLanguage); // includes resetting the _map
     } catch (e) {
       if (e instanceof ElanFileError) {
         this.parseError = e.message;

--- a/src/ide/frames/file-impl.ts
+++ b/src/ide/frames/file-impl.ts
@@ -651,28 +651,30 @@ export class FileImpl implements File {
   }
 
   setLanguageFromHeader(l: string) {
+    let lang: Language = LanguageElan.Instance;
     switch (l) {
       case "Elan": {
-        this._language = LanguageElan.Instance;
+        lang = LanguageElan.Instance;
         break;
       }
       case "Python": {
-        this._language = LanguagePython.Instance;
+        lang = LanguagePython.Instance;
         break;
       }
       case "C#": {
-        this._language = LanguageCS.Instance;
+        lang = LanguageCS.Instance;
         break;
       }
       case "VB.NET": {
-        this._language = LanguageVB.Instance;
+        lang = LanguageVB.Instance;
         break;
       }
       case "Java": {
-        this._language = LanguageJava.Instance;
+        lang = LanguageJava.Instance;
         break;
       }
     }
+    this.setLanguage(lang);
   }
 
   async parseFrom(source: CodeSource): Promise<void> {
@@ -695,11 +697,9 @@ export class FileImpl implements File {
         source.removeRegEx(Regexes.newLine, false);
         source.removeRegEx(Regexes.newLine, false);
       }
-      this.setLanguageFromHeader(language); // string
-      const savedLanguage = this._language; // Instance
       this._language = LanguageElan.Instance;
       this.parseBodyFrom(source);
-      this.setLanguage(savedLanguage); // includes resetting the _map
+      this.setLanguageFromHeader(language);
     } catch (e) {
       if (e instanceof ElanFileError) {
         this.parseError = e.message;


### PR DESCRIPTION
`src/ide/frames/file-impl.ts`.  Change the setting of the language in `setLanguageFromHeader` to first convert from the language name to the language Instance, then call `setLanguage`, so that the entries in _map get converted to the current language, as well as the _language variable being set.  `setLanguageFromHeader` is not called from anywhere else.
My first fix was to call `setLanguage` from `parseFrom`, which worked but with convoluted logic.  I did a second commit to back out that change and instead change `setLanguageFromHeader` which makes more sense.
