### PR TITLE
Some reserved word clashes are not reported during parsing #3187

### DIFF
--- a/src/ide/frames/language-cs.ts
+++ b/src/ide/frames/language-cs.ts
@@ -192,7 +192,6 @@ export class LanguageCS extends LanguageCfamily {
     `double`,
     `else`,
     `enum`,
-    ``,
     `event`,
     `explicit`,
     `extern`,

--- a/src/ide/frames/parse-nodes/abstract-alternatives.ts
+++ b/src/ide/frames/parse-nodes/abstract-alternatives.ts
@@ -37,6 +37,10 @@ export abstract class AbstractAlternatives extends AbstractParseNode {
         this.remainingText = this.bestMatch!.remainingText;
         this.alternatives = this.alternatives.filter((alt) => alt.status > ParseStatus.invalid);
       } else {
+        // pass the message up the tree
+        if (this.bestMatch!.message && !this.message) {
+          this.message = this.bestMatch!.message;
+        }
         this.bestMatch = undefined;
         this.status = ParseStatus.invalid;
         this.alternatives = [];

--- a/src/ide/frames/parse-nodes/abstract-sequence.ts
+++ b/src/ide/frames/parse-nodes/abstract-sequence.ts
@@ -29,6 +29,10 @@ export abstract class AbstractSequence extends AbstractParseNode {
       const lastNode = i === this.elements.length - 1;
       const nextNode = lastNode ? undefined : this.elements[i + 1];
       node.parseText(this.remainingText);
+      // pass the message up the tree
+      if (node.message && !this.message) {
+        this.message = node.message;
+      }
       this.remainingText = node.remainingText;
       const moreText = this.remainingText.length > 0;
       if (node.isDone()) {

--- a/src/ide/frames/parse-nodes/multiple.ts
+++ b/src/ide/frames/parse-nodes/multiple.ts
@@ -37,6 +37,10 @@ export class Multiple extends AbstractParseNode {
           toParse = node.remainingText;
           this.activeNodeForSymbolCompl = node.getActiveNode();
         } else {
+          // pass the message up the tree
+          if (node.message && !this.message) {
+            this.message = node.message;
+          }
           cont = false;
         }
         if (this.elements.length === 0 && this.minimum === 0) {

--- a/src/ide/frames/parse-nodes/optional-node.ts
+++ b/src/ide/frames/parse-nodes/optional-node.ts
@@ -26,6 +26,10 @@ export class OptionalNode extends AbstractParseNode {
         this.updateFrom(option);
         this.matchedNode = option;
       } else {
+        // pass the message up the tree
+        if (option.message && !this.message) {
+          this.message = option.message;
+        }
         this.status = ParseStatus.valid;
         this.remainingText = text;
         this._done = true;


### PR DESCRIPTION
Add code to copy the error message `message` from child parse nodes to parents on return from each `parseText` function so that the message is displayed more often when a reserved word is detected for a variable or type. (It was already OK for variable definitions.)
Also remove empty string from the list of reserved words for C-Sharp as it interfered with the rest of the fix.