### PR TITLE
Parser and symbol completion anomalies (type names) #3431

### DIFF
--- a/src/ide/frames/parse-nodes/type-name-use.ts
+++ b/src/ide/frames/parse-nodes/type-name-use.ts
@@ -57,16 +57,23 @@ export class TypeNameUse extends AbstractParseNode {
       if (this.status === ParseStatus.invalid) {
         this.attemptToMatchStandardType(text, lang.LIST_NAME, "List");
       }
-      if (this.status === ParseStatus.invalid) {
-        [this.status, this.matchedText, this.remainingText] = matchRegEx(
+      if (this.status !== ParseStatus.valid || /^\w/.test(this.remainingText)) {
+        // invalid, incomplete, or something extra on the end which continues the identifier
+        const [statusTemp, matchedTextTemp, remainingTextTemp] = matchRegEx(
           text,
           Regexes.typeSimpleName,
         );
-        this.elanTypeName = this.matchedText;
-        if (ReservedWords.Instance.matchesIgnoringCase(this.matchedText)) {
-          this.status = ParseStatus.invalid;
-          this.matchedText = "";
-          this.message = `matches a reserved word.`;
+        if (statusTemp === ParseStatus.valid) {
+          // could be a user-defined type
+          this.status = statusTemp;
+          this.matchedText = matchedTextTemp;
+          this.remainingText = remainingTextTemp;
+          this.elanTypeName = this.matchedText;
+          if (ReservedWords.Instance.matchesIgnoringCase(this.matchedText)) {
+            this.status = ParseStatus.invalid;
+            this.matchedText = "";
+            this.message = `matches a reserved word.`;
+          }
         }
       }
     }

--- a/test/parsing/parsing-nodes.test.ts
+++ b/test/parsing/parsing-nodes.test.ts
@@ -2287,7 +2287,7 @@ suite("Parsing Nodes", () => {
     testNodeParse(
       new TypeNode(fileWithVB()),
       `Inte`,
-      ParseStatus.incomplete,
+      ParseStatus.valid,
       `Inte`,
       "",
       `Inte`,
@@ -2300,11 +2300,11 @@ suite("Parsing Nodes", () => {
       new TypeNameUse(f),
       `Inte`,
       ParseStatus.valid,
-      `Int`,
-      "e",
-      `Int`,
-      "<el-type>Int</el-type>",
-      `Int`,
+      `Inte`,
+      "",
+      `Inte`,
+      "<el-type>Inte</el-type>",
+      `Inte`,
     );
   });
   test("ParamList VB", () => {


### PR DESCRIPTION
Change `parseText` in `src/ide/frames/parse-nodes/type-name-use.ts` so that type names are accepted which are prefixes of built-in types (eg `B`) or start with a built-in type eg `Intake`.  Also fix up two tests to match, eg `Inte` is now a valid type.