### PR TITLE
Backspace on new field contents #3431

### DIFF
--- a/src/ide/frames/globals/concrete-class.ts
+++ b/src/ide/frames/globals/concrete-class.ts
@@ -24,6 +24,10 @@ export class ConcreteClass extends ClassFrame {
     const newCode = this.toString.getFirstChild();
     this.toString.removeChild(newCode);
     (this.toString.getLastChild() as ReturnStatement).expr.setFieldToKnownValidText(`"undefined"`);
+    // remove the isNew flag from the return statement frame to allow
+    // Backspace to work on the "undefined" string immediately
+    // rather than trying to delete the frame, which is marked as new
+    this.toString.getLastChild().hasBeenAddedTo();
     this.getChildren().push(this.toString);
   }
 

--- a/src/ide/frames/statements/catch-statement.ts
+++ b/src/ide/frames/statements/catch-statement.ts
@@ -20,6 +20,11 @@ export class CatchStatement extends SingleLineFrame implements Statement {
     this.variable.setFieldToKnownValidText("e");
     this.exceptionType = new ExceptionTypeField(this);
     this.exceptionType.setPlaceholder(`type e.g. ElanRuntimeError or CustomError`);
+    // remove the isNew flag from the catch frame to allow
+    // Backspace to work on the identifier field "e" and
+    // the exception type field "CustomError" string immediately
+    // rather than trying to delete the frame, which is marked as new
+    this.hasBeenAddedTo();
     this.ghostable = false;
   }
 


### PR DESCRIPTION
Change new try/catch frame and new concrete class frame so that Backspace works on the default field contents by adding `hasBeenAddedTo` calls, so they are no longer marked as `isNew`.