### PR TITLE
Make Backspace delete a new try/catch statement #3431

### DIFF
--- a/src/ide/frames/abstract-selector.ts
+++ b/src/ide/frames/abstract-selector.ts
@@ -166,6 +166,13 @@ export abstract class AbstractSelector extends AbstractFrame {
 
   private selectorControlKeys = ["d", "O", "v", "?"];
 
+  // for special handling of try/catch statements, which don't have a field
+  // in the the first line to catch the Backspace
+  private deleteParentOnBackspace = false;
+  setDeleteParentOnBackspace() {
+    this.deleteParentOnBackspace = true;
+  }
+
   processKey(e: editorEvent): boolean {
     let codeHasChanged = false;
     let key = e.key;
@@ -176,6 +183,12 @@ export abstract class AbstractSelector extends AbstractFrame {
 
     switch (key) {
       case "Backspace": {
+        // Apologies for the wild casting.  Perhaps it can be done another way.
+        const par = this.getParent() as unknown as AbstractFrame;
+        if (this.deleteParentOnBackspace && par.isNew) {
+          // it is the first selector in a new TryStatement, delete the whole TryStatement
+          par.deleteIfPermissible();
+        }
         this.text = this.text.substring(0, this.text.length - 1);
         break;
       }

--- a/src/ide/frames/statements/try-statement.ts
+++ b/src/ide/frames/statements/try-statement.ts
@@ -10,6 +10,10 @@ export class TryStatement extends FrameWithStatements {
   catch: CatchStatement;
   constructor(parent: Parent) {
     super(parent);
+    // get the StatementSelector that has just been created in the call to super()
+    // and tell it to delete the TryStatement if Backspace is the next key pressed
+    // after the try/catch statement is created, while isNew is still set.
+    (this.getChildren()[0] as StatementSelector).setDeleteParentOnBackspace();
     this.catch = new CatchStatement(this);
     this.getChildren().push(this.catch);
     this.getChildren().push(new StatementSelector(this));


### PR DESCRIPTION
Add a new boolean variable `deleteParentOnBackspace` to `AbstractSelector` to tell it to delete its parent `TryStatement` if Backspace is pressed immediately after making a new `TryStatement` in case you pressed the wrong key by mistake. Set the variable from the constructor of `TryStatement`.