### PR TITLE
compiler changes: from where?

### DIFF
--- a/src/compiler/elan-type-annotations.ts
+++ b/src/compiler/elan-type-annotations.ts
@@ -288,8 +288,7 @@ export class ElanClassTypeDescriptor implements TypeDescriptor {
       const name = names[i];
 
       const metadata = Reflect.getMetadata(elanMetadataKey, this.cls.prototype, name) as
-        | ElanDescriptor
-        | undefined;
+        ElanDescriptor | undefined;
 
       if (name === "constructor") {
         children.push([

--- a/src/compiler/standard-library/std-lib-symbols.ts
+++ b/src/compiler/standard-library/std-lib-symbols.ts
@@ -40,8 +40,7 @@ export class StdLibSymbols implements Scope {
       const name = names[i];
 
       const metadata = Reflect.getMetadata(elanMetadataKey, stdlib, name) as
-        | ElanDescriptor
-        | undefined;
+        ElanDescriptor | undefined;
 
       if (isFunctionDescriptor(metadata)) {
         this.symbols.set(name, getSymbol(name, metadata.mapType(this), SymbolScope.stdlib));


### PR DESCRIPTION
Apparently just formatting of "ElanDescriptor | undefined;"