### PR TITLE
Prevent error message on Ctrl-x #3431

### DIFF
--- a/src/ide/web/code-editor-view-model.ts
+++ b/src/ide/web/code-editor-view-model.ts
@@ -761,9 +761,12 @@ export class CodeEditorViewModel implements ICodeEditorViewModel {
       msg.selection = [start, end];
     }
 
-    await this.handleKeyAndRender(msg, vm, tr);
     event.preventDefault();
     event.stopPropagation();
+    // I have just rearranged this code to put stopPropagation before the "await"
+    // so that it takes effect before the event handler finishes.
+    // The "await" is now redundant I think, but keeping it in case I break something
+    await this.handleKeyAndRender(msg, vm, tr);
   }
 
   async changeLanguage(l: Language, vm: IIDEViewModel, tr: TestRunner, always: boolean) {


### PR DESCRIPTION
Cutting with Ctrl-x causes an error message `"Cut Failed: No code to cut"` even though it works. Re-order the `event.stopPropagation` call to stop the event being acted on twice.
Sub-issue 5a in issue #3431.
`src/ide/web/code-editor-view-model.ts`
