### PR TITLE
Put focus back in right place on Ctrl-x #3431

### DIFF
--- a/src/ide/frames/abstract-frame.ts
+++ b/src/ide/frames/abstract-frame.ts
@@ -11,7 +11,6 @@ import {
   isCollapsible,
   isFrame,
   isParent,
-  isSelector,
   singleIndent,
 } from "./frame-helpers";
 import { CodeSource } from "./frame-interfaces/code-source";
@@ -25,8 +24,6 @@ import { Selectable } from "./frame-interfaces/selectable";
 import {
   parentHelper_copySelectedChildren,
   parentHelper_getAllSelectedChildren,
-  parentHelper_getChildAfter,
-  parentHelper_removeAllSelectedChildren,
 } from "./parent-helpers";
 import { CompileStatus, DisplayColour, ParseStatus } from "./status-enums";
 
@@ -406,14 +403,7 @@ export abstract class AbstractFrame implements Frame {
       this.pasteError = "Cut Failed: At least one selected frame does not parse";
       return true;
     }
-    parentHelper_removeAllSelectedChildren(this.getParent());
-
-    const last = selected[selected.length - 1];
-    const newFocus = parentHelper_getChildAfter(this.getParent(), last);
-    newFocus.select(true, false);
-    if (!isSelector(newFocus) && !newFocus.getParent().minimumNumberOfChildrenExceeded()) {
-      newFocus.insertPeerSelector(false);
-    }
+    this.getParent().deleteSelectedChildren();
     return true;
   };
 


### PR DESCRIPTION
When you delete one of more lines using Ctrl-x, the focus doesn't go back to an adjacent line as it should.  This fix makes it use the same code as Delete, which already does the right thing.
The original code, now deleted, doesn't work because it deletes the lines before trying to find the line after the last one deleted.  The result is that focus shifts to the top of the block enclosing the deleted lines.  It must have worked at one time, but presumably was modified.