### PR TITLE
Show params placeholder in Python methods #3431

### DIFF
--- a/src/ide/frames/language-python.ts
+++ b/src/ide/frames/language-python.ts
@@ -181,7 +181,11 @@ export class LanguagePython extends LanguageAbstract {
 
   paramsListAsHtml(frame: MemberFrame, field: ParamListField): string {
     const self: string = `<el-kw>${this.SELF}</el-kw>: ${selfTypeAsHtml(frame)}`;
-    return field.text === "" ? self : `${self}, ${field.renderAsHtml()}`;
+    // if no params, wrap the comma to make it only appear
+    // when the line (or parts of it) are selected
+    // if there are params, the comma appears unconditionally
+    const comma = field.text === "" ? `<el-place class="trailingcomma">, </el-place>` : ", ";
+    return `${self}${comma}${field.renderAsHtml()}`;
   }
 
   override enumValuesListAsHtml(field: EnumValuesField): string {

--- a/src/ide/styles/elanStyle.css
+++ b/src/ide/styles/elanStyle.css
@@ -562,3 +562,13 @@ el-statement.paused-at > el-fr
   .context-menu-item.separator {
     border-top: solid 1px black;
   }
+
+el-place.trailingcomma {
+  display: none;
+}
+
+.selected > el-top > el-place.trailingcomma,
+el-field.selected ~ el-place.trailingcomma,
+el-place.trailingcomma:has(+ el-field.selected) {
+  display:inline;
+}


### PR DESCRIPTION
When you create a new function method or procedure method in Python, the IDE fills in `self MyClass` but you can't click on it to add your own parameters after `self`.
Change paramsListAsHtml to always emit the trailing comma after `self MyClass`, but, if there are no params, wrapped in `el-place` tags to make it not appear when not selected.
Also always emit the parameters placeholder, which is already programmed to appear and disappear correctly.
Add rules to the CSS to make `el-place.trailingcomma` hidden except when it is selected, or things on the same line are selected.