### PR TITLE
Enums with bad syntax disappear #3431

### DIFF
--- a/src/ide/frames/language-helpers.ts
+++ b/src/ide/frames/language-helpers.ts
@@ -16,18 +16,17 @@ export function languageHelper_enumValuesList(
   ending: string,
 ): string {
   let result = "";
-  if (field.readParseStatus() === ParseStatus.valid) {
-    if (format === LineFormat.multiline) {
-      const rawValues = field.getRootNode()!.matchedText.split(",");
-      for (let i = 0; i < rawValues.length; i++) {
-        const value = rawValues[i].trim();
-        const line = `<br>  <el-id>${value}</el-id> = <el-lit>${i + startingNumber}</el-lit>`;
-        result += line;
-      }
-      result += ending;
-    } else {
-      result = field.default_renderAsHtml();
+  if (field.readParseStatus() === ParseStatus.valid && format === LineFormat.multiline) {
+    const rawValues = field.getRootNode()!.matchedText.split(",");
+    for (let i = 0; i < rawValues.length; i++) {
+      const value = rawValues[i].trim();
+      const line = `<br>  <el-id>${value}</el-id> = <el-lit>${i + startingNumber}</el-lit>`;
+      result += line;
     }
+    result += ending;
+  } else {
+    // bad parse status or format is inline
+    result = field.default_renderAsHtml();
   }
   return result;
 }


### PR DESCRIPTION
If you enter text with bad syntax for the value of an Enum, it disappears when you hit Tab or Enter.
Change the logic in `languageHelper_enumValuesList` so that the text is still displayed even if the parse status is bad.
Note that I have just merged the two `if` statements, removed one closing brace, and added a comment further down.
The block controlled by the `if` statements shows as different, but it is only the indentation which has changed.