### PR TITLE
Stop compile errors disappearing with constant #3480

### DIFF
--- a/src/compiler/syntax-nodes/file-asn.ts
+++ b/src/compiler/syntax-nodes/file-asn.ts
@@ -47,6 +47,24 @@ export class FileAsn extends AbstractAstNode implements RootAstNode, Scope {
     if (this.scopeMap.has(id)) {
       return this.scopeMap.get(id)!;
     }
+    // Sometimes the language in the map doesn't match the language in the id.
+    // We can't make a new map for each language by making a new FileAsn
+    // because it wipes the positions of any compile errors.
+    // Make a new id with the correct language for this map.
+    // This is more efficient than doing a language-independent search
+    // through every item in the map.
+    // We extract the language being used for this map (the part before the underbar)
+    // from the first entry in the map (they all use the same language),
+    // and change the language in the id to match it.
+    const firstEntry = this.scopeMap.keys().next().value;
+    if (firstEntry) {
+      // make a new id with the correct language for this map
+      const newid =
+        firstEntry.substring(0, firstEntry.indexOf("_")) + id.substring(id.indexOf("_"));
+      if (this.scopeMap.has(newid)) {
+        return this.scopeMap.get(newid)!;
+      }
+    }
     return NullScope.Instance;
   }
 

--- a/src/ide/frames/fields/constant-value-field.ts
+++ b/src/ide/frames/fields/constant-value-field.ts
@@ -27,7 +27,7 @@ export class ConstantValueField extends AbstractField {
   }
 
   getElanType() {
-    const scope = this.getFile().getAst(true)?.getScopeById(this.getHolder().getHtmlId());
+    const scope = this.getFile().getAst(false)?.getScopeById(this.getHolder().getHtmlId());
     if (isSymbol(scope)) {
       return scope.symbolType().name;
     }


### PR DESCRIPTION
`constant-value-field.ts:`
Don't make a new FileAsn in `getElanType` to avoid clearing compile error details.
`getAst(true) -> getAst(false)`
`file-asn.ts:`
Allow language-independent lookup of scope by htmlId in `getScopeById`.