### PR TITLE
Set language to Elan while pasting #3501

### DIFF
--- a/src/ide/frames/abstract-selector.ts
+++ b/src/ide/frames/abstract-selector.ts
@@ -269,6 +269,11 @@ export abstract class AbstractSelector extends AbstractFrame {
   }
 
   paste = (code?: string): boolean => {
+    // Get the current language to put back later
+    const oldLanguage = this.getFile().language();
+    // The text pasted in is always in Elan language
+    this.getFile().setLanguageToElan();
+
     try {
       code = (code ?? "").trim() + "\n";
 
@@ -288,6 +293,12 @@ export abstract class AbstractSelector extends AbstractFrame {
     } catch (_e) {
       this.pasteError = `Paste failed: Cannot paste '${code}' into prompt`;
     }
+
+    // Set the language back to the original value.
+    // If the language has changed, this also calls
+    // resetFieldText and resetMap to translate the expressions etc
+    // to the current language, and make the map of htmlId's correct.
+    this.getFile().setLanguage(oldLanguage);
 
     return true;
   };

--- a/src/ide/frames/file-impl.ts
+++ b/src/ide/frames/file-impl.ts
@@ -935,6 +935,12 @@ export class FileImpl implements File {
     return false;
   }
 
+  // A short function needed by AbstractSelector because importing
+  // LanguageElan.Instance there causes a dependency loop.
+  setLanguageToElan() {
+    this.setLanguage(LanguageElan.Instance);
+  }
+
   private resetFieldText(): void {
     parentHelper_resetFieldTextOnChildren(this);
   }

--- a/src/ide/frames/frame-interfaces/file.ts
+++ b/src/ide/frames/frame-interfaces/file.ts
@@ -126,6 +126,7 @@ export interface File extends Parent {
 
   setLanguage(l: Language): boolean;
   language(): Language;
+  setLanguageToElan(): void;
 
   showCompletion(show: boolean): void;
   getShowCompletion(): boolean;


### PR DESCRIPTION
Set the language to Elan during any paste operation, as the pasted text is always in Elan (aka Reference Language).
Set the language back to the original when the pasting is done.
The `AbstractSelector` class which does the pasting does not otherwise use `LanguageElan.Instance`, and adding an import statement for it introduces a dependency loop.
So add a new function `setLanguageToElan()` to the `File` interface and `FileImpl` implementation, which does already use `LanguageElan.Instance`.
This change may affect performance on long programs as the whole program is re-processed when the language is restored to its original setting, not just the part pasted.
But it works AFAICT.